### PR TITLE
🗑️ Departmentモデルからcolorpaletteフィールドを削除

### DIFF
--- a/app/admin/certifications/types.ts
+++ b/app/admin/certifications/types.ts
@@ -4,7 +4,6 @@ export interface CertificationWithDepartment extends Certification {
   department: {
     id: number
     name: string
-    colorPalette: string
   }
 }
 

--- a/app/api/certifications/[id]/route.test.ts
+++ b/app/api/certifications/[id]/route.test.ts
@@ -68,7 +68,6 @@ describe('GET /api/certifications/[id]', () => {
         department: {
           id: 1,
           name: 'スキー',
-          colorPalette: 'red'
         },
         instructorCertifications: [
           {
@@ -103,7 +102,6 @@ describe('GET /api/certifications/[id]', () => {
         department: {
           id: 1,
           name: 'スキー',
-          colorPalette: 'red'
         },
         instructors: [
           {
@@ -138,8 +136,7 @@ describe('GET /api/certifications/[id]', () => {
           department: {
             select: {
               id: true,
-              name: true,
-              colorPalette: true
+              name: true
             }
           },
           instructorCertifications: {
@@ -180,7 +177,6 @@ describe('GET /api/certifications/[id]', () => {
         department: {
           id: 2,
           name: 'スノーボード',
-          colorPalette: 'blue'
         },
         instructorCertifications: []
       }
@@ -198,7 +194,6 @@ describe('GET /api/certifications/[id]', () => {
         department: {
           id: 2,
           name: 'スノーボード',
-          colorPalette: 'blue'
         },
         instructors: []
       }
@@ -241,8 +236,7 @@ describe('GET /api/certifications/[id]', () => {
           department: {
             select: {
               id: true,
-              name: true,
-              colorPalette: true
+              name: true
             }
           },
           instructorCertifications: {
@@ -315,8 +309,7 @@ describe('GET /api/certifications/[id]', () => {
           department: {
             select: {
               id: true,
-              name: true,
-              colorPalette: true
+              name: true
             }
           },
           instructorCertifications: {
@@ -363,7 +356,7 @@ describe('GET /api/certifications/[id]', () => {
         isActive: true,
         createdAt: new Date('2024-01-01'),
         updatedAt: new Date('2024-01-01'),
-        department: { id: 1, name: 'Test Dept', colorPalette: 'red' },
+        department: { id: 1, name: 'Test Dept' },
         instructorCertifications: []
       }
       mockCertificationFindUnique.mockResolvedValue(mockCertificationFromDB)
@@ -382,8 +375,7 @@ describe('GET /api/certifications/[id]', () => {
           department: {
             select: {
               id: true,
-              name: true,
-              colorPalette: true
+              name: true
             }
           },
           instructorCertifications: {
@@ -435,8 +427,7 @@ describe('GET /api/certifications/[id]', () => {
             department: {
               select: {
                 id: true,
-                name: true,
-                colorPalette: true
+                name: true
               }
             },
             instructorCertifications: {
@@ -515,7 +506,6 @@ describe('PUT /api/certifications/[id]', () => {
         department: {
           id: 1,
           name: 'スキー',
-          colorPalette: 'red'
         }
       }
 
@@ -544,8 +534,7 @@ describe('PUT /api/certifications/[id]', () => {
           department: {
             select: {
               id: true,
-              name: true,
-              colorPalette: true
+              name: true
             }
           }
         }
@@ -580,7 +569,6 @@ describe('PUT /api/certifications/[id]', () => {
         department: {
           id: 2,
           name: 'スノーボード',
-          colorPalette: 'blue'
         }
       }
 
@@ -609,8 +597,7 @@ describe('PUT /api/certifications/[id]', () => {
           department: {
             select: {
               id: true,
-              name: true,
-              colorPalette: true
+              name: true
             }
           }
         }
@@ -810,7 +797,6 @@ describe('PUT /api/certifications/[id]', () => {
         department: {
           id: 1,
           name: 'テスト部門',
-          colorPalette: 'red'
         }
       }
 
@@ -839,8 +825,7 @@ describe('PUT /api/certifications/[id]', () => {
           department: {
             select: {
               id: true,
-              name: true,
-              colorPalette: true
+              name: true
             }
           }
         }
@@ -868,7 +853,6 @@ describe('PUT /api/certifications/[id]', () => {
         department: {
           id: 1,
           name: 'テスト部門',
-          colorPalette: 'red'
         }
       }
 
@@ -907,7 +891,6 @@ describe('PUT /api/certifications/[id]', () => {
         department: {
           id: 1,
           name: 'テスト部門',
-          colorPalette: 'red'
         }
       }
 
@@ -928,8 +911,7 @@ describe('PUT /api/certifications/[id]', () => {
             department: {
               select: {
                 id: true,
-                name: true,
-                colorPalette: true
+                name: true
               }
             }
           }

--- a/app/api/certifications/[id]/route.ts
+++ b/app/api/certifications/[id]/route.ts
@@ -30,7 +30,6 @@ export async function GET(request: Request, context: RouteContext) {
           select: {
             id: true,
             name: true,
-            colorPalette: true
           }
         },
         instructorCertifications: {
@@ -140,7 +139,6 @@ export async function PUT(request: Request, context: RouteContext) {
           select: {
             id: true,
             name: true,
-            colorPalette: true
           }
         }
       }

--- a/app/api/certifications/route.test.ts
+++ b/app/api/certifications/route.test.ts
@@ -15,7 +15,6 @@ type Certification = {
   department: {
     id: number
     name: string
-    colorPalette: string
   }
 }
 
@@ -84,8 +83,7 @@ describe('GET /api/certifications', () => {
           updatedAt: new Date('2024-01-01'),
           department: {
             id: 1,
-            name: 'スキー',
-            colorPalette: 'red'
+            name: 'スキー'
           }
         },
         {
@@ -100,8 +98,7 @@ describe('GET /api/certifications', () => {
           updatedAt: new Date('2024-01-01'),
           department: {
             id: 2,
-            name: 'スノーボード',
-            colorPalette: 'blue'
+            name: 'スノーボード'
           }
         },
       ]
@@ -117,8 +114,7 @@ describe('GET /api/certifications', () => {
           department: {
             select: {
               id: true,
-              name: true,
-              colorPalette: true
+              name: true
             }
           }
         },
@@ -151,8 +147,7 @@ describe('GET /api/certifications', () => {
           department: {
             select: {
               id: true,
-              name: true,
-              colorPalette: true
+              name: true
             }
           }
         },
@@ -186,8 +181,7 @@ describe('GET /api/certifications', () => {
           updatedAt: new Date('2024-01-01'),
           department: {
             id: 1,
-            name: 'スキー',
-            colorPalette: 'red'
+            name: 'スキー'
           }
         },
       ]
@@ -226,8 +220,7 @@ describe('GET /api/certifications', () => {
           department: {
             select: {
               id: true,
-              name: true,
-              colorPalette: true
+              name: true
             }
           }
         },
@@ -288,12 +281,12 @@ describe('GET /api/certifications', () => {
         { 
           id: 1, 
           name: 'スキー指導員',
-          department: { id: 1, name: 'スキー', colorPalette: 'red' }
+          department: { id: 1, name: 'スキー' }
         },
         { 
           id: 2, 
           name: 'スノーボード指導員',
-          department: { id: 2, name: 'スノーボード', colorPalette: 'blue' }
+          department: { id: 2, name: 'スノーボード' }
         },
       ]
       mockCertificationFindMany.mockResolvedValue(mockCertifications as Certification[])
@@ -307,8 +300,7 @@ describe('GET /api/certifications', () => {
           department: {
             select: {
               id: true,
-              name: true,
-              colorPalette: true
+              name: true
             }
           }
         },
@@ -344,8 +336,7 @@ describe('GET /api/certifications', () => {
             department: {
               select: {
                 id: true,
-                name: true,
-                colorPalette: true
+                name: true
               }
             }
           }
@@ -411,8 +402,7 @@ describe('POST /api/certifications', () => {
         updatedAt: new Date('2024-01-01'),
         department: {
           id: 1,
-          name: 'スキー',
-          colorPalette: 'red'
+          name: 'スキー'
         }
       }
 
@@ -436,8 +426,7 @@ describe('POST /api/certifications', () => {
           department: {
             select: {
               id: true,
-              name: true,
-              colorPalette: true
+              name: true
             }
           }
         }
@@ -474,8 +463,7 @@ describe('POST /api/certifications', () => {
         updatedAt: new Date('2024-01-01'),
         department: {
           id: 1,
-          name: 'スキー',
-          colorPalette: 'red'
+          name: 'スキー'
         }
       }
 
@@ -499,8 +487,7 @@ describe('POST /api/certifications', () => {
           department: {
             select: {
               id: true,
-              name: true,
-              colorPalette: true
+              name: true
             }
           }
         }

--- a/app/api/certifications/route.ts
+++ b/app/api/certifications/route.ts
@@ -8,8 +8,7 @@ export async function GET() {
         department: {
           select: {
             id: true,
-            name: true,
-            colorPalette: true
+            name: true
           }
         }
       },
@@ -74,8 +73,7 @@ export async function POST(request: Request) {
         department: {
           select: {
             id: true,
-            name: true,
-            colorPalette: true
+            name: true
           }
         }
       }

--- a/app/api/departments/[id]/route.test.ts
+++ b/app/api/departments/[id]/route.test.ts
@@ -38,7 +38,6 @@ describe('/api/departments/[id] GET', () => {
       name: 'スキー',
       description: 'スキー部門',
       isActive: true,
-      colorPalette: 'red',
       createdAt: new Date('2024-01-01'),
       updatedAt: new Date('2024-01-01'),
     }
@@ -60,7 +59,6 @@ describe('/api/departments/[id] GET', () => {
         name: 'スキー',
         description: 'スキー部門',
         isActive: true,
-        colorPalette: 'red',
         createdAt: '2024-01-01T00:00:00.000Z',
         updatedAt: '2024-01-01T00:00:00.000Z',
       },

--- a/app/api/departments/route.test.ts
+++ b/app/api/departments/route.test.ts
@@ -8,7 +8,6 @@ type Department = {
   name: string
   description: string | null
   isActive: boolean
-  colorPalette: string
   createdAt: Date
   updatedAt: Date
 }
@@ -70,7 +69,6 @@ describe('GET /api/departments', () => {
           name: 'スキー',
           description: 'スキー部門',
           isActive: true,
-          colorPalette: '#FF0000',
           createdAt: new Date('2024-01-01'),
           updatedAt: new Date('2024-01-01'),
         },
@@ -80,7 +78,6 @@ describe('GET /api/departments', () => {
           name: 'スノーボード',
           description: 'スノーボード部門',
           isActive: true,
-          colorPalette: '#0000FF',
           createdAt: new Date('2024-01-01'),
           updatedAt: new Date('2024-01-01'),
         },
@@ -140,7 +137,6 @@ describe('GET /api/departments', () => {
           name: 'スキー',
           description: 'スキー部門',
           isActive: true,
-          colorPalette: '#FF0000',
           createdAt: new Date('2024-01-01'),
           updatedAt: new Date('2024-01-01'),
         },

--- a/docs/db.md
+++ b/docs/db.md
@@ -9,7 +9,7 @@ OpenAPI 仕様書（docs/api/openapi.yaml）に基づいて設計されていま
 
 - **データベース**: Cloudflare D1 (SQLite)
 - **ORM**: Prisma 6.12
-- **識別子**: INTEGER PRIMARY KEY (SQLiteネイティブのAUTOINCREMENT)
+- **識別子**: INTEGER PRIMARY KEY (SQLite ネイティブの AUTOINCREMENT)
 
 ## エンティティ関係図（ER 図）
 
@@ -115,16 +115,16 @@ erDiagram
 - スキー部門: `"blue"` → `bg-blue-500`, `text-blue-700`, `border-blue-300` など
 - スノーボード部門: `"emerald"` → `bg-emerald-500`, `text-emerald-700`, `border-emerald-300` など
 
-| カラム名      | データ型 | 制約                        | 説明                                                               |
-| ------------- | -------- | --------------------------- | ------------------------------------------------------------------ |
-| id            | INTEGER  | PRIMARY KEY AUTOINCREMENT   | 部門 ID                                                            |
-| code          | TEXT     | UNIQUE NOT NULL             | 部門コード（例: "ski", "snowboard"）                               |
-| name          | TEXT     | NOT NULL                    | 部門名（例: "スキー", "スノーボード"）                             |
-| description   | TEXT     |                             | 説明・備考                                                         |
-| is_active     | BOOLEAN  | DEFAULT TRUE                | アクティブ状態                                                     |
+| カラム名      | データ型 | 制約                        | 説明                                                   |
+| ------------- | -------- | --------------------------- | ------------------------------------------------------ |
+| id            | INTEGER  | PRIMARY KEY AUTOINCREMENT   | 部門 ID                                                |
+| code          | TEXT     | UNIQUE NOT NULL             | 部門コード（例: "ski", "snowboard"）                   |
+| name          | TEXT     | NOT NULL                    | 部門名（例: "スキー", "スノーボード"）                 |
+| description   | TEXT     |                             | 説明・備考                                             |
+| is_active     | BOOLEAN  | DEFAULT TRUE                | アクティブ状態                                         |
 | color_palette | TEXT     | NOT NULL                    | Tailwind CSS カラーパレット名（例: "blue", "emerald"） |
-| created_at    | DATETIME | DEFAULT CURRENT_TIMESTAMP   | 作成日時                                                           |
-| updated_at    | DATETIME | ON UPDATE CURRENT_TIMESTAMP | 更新日時                                                           |
+| created_at    | DATETIME | DEFAULT CURRENT_TIMESTAMP   | 作成日時                                               |
+| updated_at    | DATETIME | ON UPDATE CURRENT_TIMESTAMP | 更新日時                                               |
 
 **インデックス:**
 
@@ -235,21 +235,20 @@ erDiagram
 
 シフト枠を管理するテーブル。
 
-| カラム名       | データ型 | 制約                        | 説明                |
-| -------------- | -------- | --------------------------- | ------------------- |
-| id             | INTEGER  | PRIMARY KEY AUTOINCREMENT   | シフト ID           |
-| date           | DATETIME | NOT NULL                    | シフト日時          |
-| department_id  | INTEGER  | NOT NULL                    | 部門 ID（FK）       |
-| shift_type_id  | INTEGER  | NOT NULL                    | シフト種類 ID（FK） |
-| description    | TEXT     |                             | 説明・備考          |
-| created_at     | DATETIME | DEFAULT CURRENT_TIMESTAMP   | 作成日時            |
-| updated_at     | DATETIME | ON UPDATE CURRENT_TIMESTAMP | 更新日時            |
+| カラム名      | データ型 | 制約                        | 説明                |
+| ------------- | -------- | --------------------------- | ------------------- |
+| id            | INTEGER  | PRIMARY KEY AUTOINCREMENT   | シフト ID           |
+| date          | DATETIME | NOT NULL                    | シフト日時          |
+| department_id | INTEGER  | NOT NULL                    | 部門 ID（FK）       |
+| shift_type_id | INTEGER  | NOT NULL                    | シフト種類 ID（FK） |
+| description   | TEXT     |                             | 説明・備考          |
+| created_at    | DATETIME | DEFAULT CURRENT_TIMESTAMP   | 作成日時            |
+| updated_at    | DATETIME | ON UPDATE CURRENT_TIMESTAMP | 更新日時            |
 
 **外部キー制約:**
 
 - FOREIGN KEY (department_id) REFERENCES departments(id)
 - FOREIGN KEY (shift_type_id) REFERENCES shift_types(id)
-
 
 **インデックス:**
 
@@ -264,12 +263,12 @@ erDiagram
 
 シフトとインストラクターの多対多関係を管理する中間テーブル。
 
-| カラム名      | データ型 | 制約                        | 説明                      |
-| ------------- | -------- | --------------------------- | ------------------------- |
-| id            | INTEGER  | PRIMARY KEY AUTOINCREMENT   | 割り当て ID               |
-| shift_id      | INTEGER  | NOT NULL                    | シフト ID（FK）           |
-| instructor_id | INTEGER  | NOT NULL                    | インストラクター ID（FK） |
-| assigned_at   | DATETIME | DEFAULT CURRENT_TIMESTAMP   | 割り当て日時              |
+| カラム名      | データ型 | 制約                      | 説明                      |
+| ------------- | -------- | ------------------------- | ------------------------- |
+| id            | INTEGER  | PRIMARY KEY AUTOINCREMENT | 割り当て ID               |
+| shift_id      | INTEGER  | NOT NULL                  | シフト ID（FK）           |
+| instructor_id | INTEGER  | NOT NULL                  | インストラクター ID（FK） |
+| assigned_at   | DATETIME | DEFAULT CURRENT_TIMESTAMP | 割り当て日時              |
 
 **外部キー制約:**
 
@@ -288,7 +287,6 @@ erDiagram
 - INDEX idx_shift_assignments_instructor_id (instructor_id)
 - INDEX idx_shift_assignments_assigned_at (assigned_at)
 
-
 ## パフォーマンス設計
 
 ### 高頻度アクセスパターンとインデックス戦略
@@ -296,11 +294,13 @@ erDiagram
 #### 1. シフト検索の最適化
 
 **主要なクエリパターン:**
+
 - 日付範囲でのシフト一覧取得
 - 部門別・シフト種類別のフィルタリング
 - シフト割り当て状況の確認
 
 **最適化されたインデックス:**
+
 ```sql
 -- 基本インデックス（テーブル定義で既に定義済み）
 -- - idx_shifts_date (date)
@@ -317,11 +317,13 @@ CREATE INDEX idx_shifts_covering ON shifts(date, department_id, shift_type_id);
 #### 2. インストラクター検索の最適化
 
 **主要なクエリパターン:**
+
 - 名前検索（ひらがな・カタカナ・漢字）
 - ステータス別フィルタリング
 - 資格保有者検索
 
 **最適化されたインデックス:**
+
 ```sql
 -- 基本インデックス（テーブル定義で既に定義済み）
 -- - idx_instructors_name (last_name, first_name)
@@ -339,11 +341,13 @@ CREATE INDEX idx_instructors_active_name ON instructors(last_name, first_name) W
 #### 3. シフト割り当て検索の最適化
 
 **主要なクエリパターン:**
+
 - インストラクター別のシフト履歴
 - シフト別の割り当て一覧
 - 期間指定での割り当て統計
 
 **最適化されたインデックス:**
+
 ```sql
 -- 基本インデックス（テーブル定義で既に定義済み）
 -- - idx_shift_assignments_shift_id (shift_id)
@@ -361,9 +365,10 @@ CREATE INDEX idx_assignments_shift_covering ON shift_assignments(shift_id, instr
 
 ### クエリ最適化指針
 
-#### 効率的なJOIN戦略
+#### 効率的な JOIN 戦略
 
 1. **シフト一覧の取得（関連データ込み）**
+
    ```sql
    -- 最適化されたクエリ例
    SELECT s.*, d.name as department_name, st.name as shift_type_name,
@@ -390,11 +395,12 @@ CREATE INDEX idx_assignments_shift_covering ON shift_assignments(shift_id, instr
      AND c.is_active = true;
    ```
 
-### SQLite固有の最適化
+### SQLite 固有の最適化
 
-#### Cloudflare D1での最適化ポイント
+#### Cloudflare D1 での最適化ポイント
 
-1. **PRAGMA設定の活用**
+1. **PRAGMA 設定の活用**
+
    ```sql
    PRAGMA journal_mode = WAL;
    PRAGMA synchronous = NORMAL;
@@ -403,9 +409,10 @@ CREATE INDEX idx_assignments_shift_covering ON shift_assignments(shift_id, instr
    ```
 
 2. **効率的なページング**
+
    ```sql
    -- カーソルベースページング（OFFSET避ける）
-   SELECT * FROM shifts 
+   SELECT * FROM shifts
    WHERE date >= ?
    ORDER BY date, id
    LIMIT 20;
@@ -419,7 +426,6 @@ CREATE INDEX idx_assignments_shift_covering ON shift_assignments(shift_id, instr
    WHERE date >= date('now', 'start of month')
    GROUP BY department_id;
    ```
-
 
 ## データ整合性
 
@@ -439,18 +445,17 @@ CREATE INDEX idx_assignments_shift_covering ON shift_assignments(shift_id, instr
 - インストラクター・資格関連の重複防止
 - シフト割り当ての重複防止
 
-
 ## API 仕様との対応表
 
-| API エンティティ        | テーブル名                | 主な対応フィールド                                 |
-| ----------------------- | ------------------------- | -------------------------------------------------- |
-| Department              | departments               | id, code, name, description, isActive, colorPalette |
-| Certification           | certifications            | id, departmentId, name, shortName, organization    |
-| Instructor              | instructors               | id, lastName, firstName, status, notes             |
-| InstructorCertification | instructor_certifications | id, instructorId, certificationId                  |
-| ShiftType               | shift_types               | id, name, isActive                                 |
-| Shift                   | shifts                    | id, date, departmentId, shiftTypeId, description   |
-| ShiftAssignment         | shift_assignments         | id, shiftId, instructorId, assignedAt              |
+| API エンティティ        | テーブル名                | 主な対応フィールド                               |
+| ----------------------- | ------------------------- | ------------------------------------------------ |
+| Department              | departments               | id, code, name, description, isActive            |
+| Certification           | certifications            | id, departmentId, name, shortName, organization  |
+| Instructor              | instructors               | id, lastName, firstName, status, notes           |
+| InstructorCertification | instructor_certifications | id, instructorId, certificationId                |
+| ShiftType               | shift_types               | id, name, isActive                               |
+| Shift                   | shifts                    | id, date, departmentId, shiftTypeId, description |
+| ShiftAssignment         | shift_assignments         | id, shiftId, instructorId, assignedAt            |
 
 ---
 
@@ -459,5 +464,5 @@ CREATE INDEX idx_assignments_shift_covering ON shift_assignments(shift_id, instr
 
 ### 変更履歴
 
-- **v1.1.0 (2025-07-22)**: ID戦略をINTEGER PRIMARY KEY AUTOINCREMENTに変更（パフォーマンス最適化）
+- **v1.1.0 (2025-07-22)**: ID 戦略を INTEGER PRIMARY KEY AUTOINCREMENT に変更（パフォーマンス最適化）
 - **v1.0.0 (2025-07-21)**: 初版リリース

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -637,9 +637,6 @@ components:
         name:
           type: string
           example: "スキー"
-        colorPalette:
-          type: string
-          example: "red"
 
     InstructorSummary:
       type: object
@@ -750,9 +747,6 @@ components:
         isActive:
           type: boolean
           default: true
-        colorPalette:
-          type: string
-          example: "red"
         createdAt:
           type: string
           format: date-time
@@ -765,7 +759,6 @@ components:
       required:
         - code
         - name
-        - colorPalette
       properties:
         code:
           type: string
@@ -779,9 +772,6 @@ components:
         isActive:
           type: boolean
           default: true
-        colorPalette:
-          type: string
-          example: "red"
 
     # 資格関連
     Certification:

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,7 +23,6 @@ model Department {
   name         String
   description  String?
   isActive     Boolean @default(true) @map("is_active")
-  colorPalette String  @map("color_palette")
   createdAt    DateTime @default(now()) @map("created_at")
   updatedAt    DateTime @updatedAt @map("updated_at")
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -25,7 +25,6 @@ async function main() {
       code: "ski",
       name: "スキー",
       description: "スキー部門",
-      colorPalette: "blue",
     },
   });
 
@@ -34,7 +33,6 @@ async function main() {
       code: "snowboard",
       name: "スノーボード",
       description: "スノーボード部門",
-      colorPalette: "amber",
     },
   });
 


### PR DESCRIPTION
## 概要

Departmentモデルから不要な`colorPalette`フィールドを削除しました。

## 変更内容

- **データベーススキーマ**: `prisma/schema.prisma`から`colorPalette`フィールドを削除
- **API**: 全てのDepartment関連APIレスポンスから`colorPalette`を除去
- **型定義**: TypeScript型定義から`colorPalette`プロパティを削除
- **テスト**: テストデータとモックオブジェクトから`colorPalette`を削除
- **ドキュメント**: OpenAPI仕様書とデータベース設計書を更新

## 影響範囲

### 変更されたファイル
- `prisma/schema.prisma` - Departmentモデル定義
- `prisma/seed.ts` - シードデータ
- `app/api/certifications/**` - 資格関連API (Departmentを含むレスポンス)
- `app/api/departments/**` - 部門関連API
- `app/admin/certifications/types.ts` - 型定義
- `docs/openapi.yaml` - API仕様書
- `docs/db.md` - データベース設計書

### 削除された機能
- Department APIレスポンスでの`colorPalette`フィールド
- 関連する型定義とテストデータ

## テスト

- 既存のテストケースが全て`colorPalette`なしで正常に動作することを確認済み
- APIレスポンスの整合性を維持

## 注意事項

- リリース前のアプリケーションのため、データベースマイグレーションは不要
- フロントエンド側で`colorPalette`を使用している箇所がある場合は別途対応が必要

## チェックリスト

- [x] スキーマ変更
- [x] API更新
- [x] テスト更新
- [x] 型定義更新
- [x] ドキュメント更新