### PR TITLE
✨ Add shift type management feature with GitHub MCP configuration updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,4 +10,4 @@ NEXT_PUBLIC_APP_URL="http://localhost:3000"
 # GitHub Personal Access Token for MCP GitHub server
 # Create a personal access token at: https://github.com/settings/tokens
 # Required scopes: repo (for repository access)
-GITHUB_PERSONAL_ACCESS_TOKEN="your_github_token_here"
+GITHUB_TOKEN="your_github_token_here"

--- a/.mcp.json
+++ b/.mcp.json
@@ -24,10 +24,7 @@
     },
     "github": {
       "command": "docker",
-      "args": ["run", "-i", "--rm", "-e", "GITHUB_PERSONAL_ACCESS_TOKEN", "mcp/github-mcp-server"],
-      "env": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
-      }
+      "args": ["run", "-i", "--rm", "--env-file", ".env", "ghcr.io/github/github-mcp-server"]
     }
   }
 }

--- a/app/admin/shift-types/ShiftTypeModal.tsx
+++ b/app/admin/shift-types/ShiftTypeModal.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Tag } from '@phosphor-icons/react';
+import type { ShiftTypeModalProps, ShiftTypeFormData } from './types';
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerFooter,
+} from '@/components/ui/drawer';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+
+export default function ShiftTypeModal({
+  isOpen,
+  onClose,
+  shiftType,
+  onSave,
+}: ShiftTypeModalProps) {
+  const [formData, setFormData] = useState<ShiftTypeFormData>({
+    name: '',
+    isActive: true,
+  });
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (shiftType) {
+      // 編集モード
+      setFormData({
+        name: shiftType.name,
+        isActive: shiftType.isActive,
+      });
+    } else {
+      // 新規追加モード
+      setFormData({
+        name: '',
+        isActive: true,
+      });
+    }
+  }, [shiftType, isOpen]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+
+    try {
+      await onSave(formData);
+      onClose();
+    } catch (error) {
+      console.error('Save error:', error);
+      alert(error instanceof Error ? error.message : '保存に失敗しました');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Drawer open={isOpen} onOpenChange={onClose}>
+      <DrawerContent>
+        <div className="mx-auto w-full max-w-7xl">
+          <DrawerHeader>
+            <DrawerTitle className="flex items-center gap-2 text-2xl">
+              <Tag className="h-6 w-6" weight="regular" />
+              {shiftType ? 'シフト種類編集' : '新しいシフト種類を追加'}
+            </DrawerTitle>
+          </DrawerHeader>
+
+          <ScrollArea className="h-auto max-h-[60vh] overflow-auto overflow-y-auto p-4">
+            <form id="shift-type-form" onSubmit={handleSubmit} className="space-y-6">
+              {/* 基本情報セクション */}
+              <div className="space-y-4">
+                {/* シフト種類名 */}
+                <div className="space-y-2">
+                  <Label htmlFor="name" className="text-sm font-medium">
+                    シフト種類名 <span className="text-destructive">*</span>
+                  </Label>
+                  <div className="max-w-md">
+                    <Input
+                      id="name"
+                      placeholder="例: 午前レッスン"
+                      value={formData.name}
+                      onChange={(e) => setFormData((prev) => ({ ...prev, name: e.target.value }))}
+                      required
+                    />
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    シフト種類の名前を入力してください
+                  </p>
+                </div>
+
+                {/* 有効/無効の設定 */}
+                <div className="space-y-2">
+                  <Label className="text-sm font-medium">有効</Label>
+                  <div className="flex items-center space-x-2">
+                    <Switch
+                      checked={formData.isActive}
+                      onCheckedChange={(checked) =>
+                        setFormData((prev) => ({
+                          ...prev,
+                          isActive: checked,
+                        }))
+                      }
+                    />
+                    <Label className="text-sm text-muted-foreground">
+                      {formData.isActive ? '有効' : '無効'}
+                    </Label>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    無効にしたシフト種類は新規割り当てができなくなります
+                  </p>
+                </div>
+              </div>
+            </form>
+          </ScrollArea>
+
+          <DrawerFooter>
+            <div className="flex w-full gap-2">
+              <DrawerClose asChild>
+                <Button type="button" variant="outline" disabled={isSubmitting} className="flex-1">
+                  キャンセル
+                </Button>
+              </DrawerClose>
+              <Button
+                type="submit"
+                form="shift-type-form"
+                disabled={isSubmitting}
+                className="flex-1"
+              >
+                {isSubmitting ? '保存中...' : '保存'}
+              </Button>
+            </div>
+          </DrawerFooter>
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/app/admin/shift-types/api.ts
+++ b/app/admin/shift-types/api.ts
@@ -1,0 +1,63 @@
+import type { ShiftType, ShiftTypeFormData } from './types';
+
+const API_BASE = '/api/shift-types';
+
+export async function fetchShiftTypes(): Promise<ShiftType[]> {
+  const response = await fetch(API_BASE);
+
+  if (!response.ok) {
+    throw new Error('シフト種類の取得に失敗しました');
+  }
+
+  const result = await response.json();
+
+  if (result.success === false) {
+    throw new Error(result.error || 'シフト種類の取得に失敗しました');
+  }
+
+  return result.data || result;
+}
+
+export async function createShiftType(data: ShiftTypeFormData): Promise<ShiftType> {
+  const response = await fetch(API_BASE, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(data),
+  });
+
+  if (!response.ok) {
+    throw new Error('シフト種類の作成に失敗しました');
+  }
+
+  const result = await response.json();
+
+  if (result.success === false) {
+    throw new Error(result.error || 'シフト種類の作成に失敗しました');
+  }
+
+  return result.data || result;
+}
+
+export async function updateShiftType(id: number, data: ShiftTypeFormData): Promise<ShiftType> {
+  const response = await fetch(`${API_BASE}/${id}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(data),
+  });
+
+  if (!response.ok) {
+    throw new Error('シフト種類の更新に失敗しました');
+  }
+
+  const result = await response.json();
+
+  if (result.success === false) {
+    throw new Error(result.error || 'シフト種類の更新に失敗しました');
+  }
+
+  return result.data || result;
+}

--- a/app/admin/shift-types/page.tsx
+++ b/app/admin/shift-types/page.tsx
@@ -1,0 +1,284 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { Plus, Tag, SealCheck } from '@phosphor-icons/react';
+import ShiftTypeModal from './ShiftTypeModal';
+import { fetchShiftTypes, createShiftType, updateShiftType } from './api';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import type { ShiftType, ShiftTypeFormData, ShiftTypeStats } from './types';
+
+export default function ShiftTypesPage() {
+  const [shiftTypes, setShiftTypes] = useState<ShiftType[]>([]);
+  const [filteredShiftTypes, setFilteredShiftTypes] = useState<ShiftType[]>([]);
+  const [showActiveOnly, setShowActiveOnly] = useState<boolean>(true);
+  const [stats, setStats] = useState<ShiftTypeStats>({
+    total: 0,
+    active: 0,
+  });
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [editingShiftType, setEditingShiftType] = useState<ShiftType | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadShiftTypes = async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const data = await fetchShiftTypes();
+      setShiftTypes(data);
+    } catch (error) {
+      console.error('Failed to load shift types:', error);
+      setError(error instanceof Error ? error.message : 'データの取得に失敗しました');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const applyFilter = useCallback(() => {
+    let filtered = [...shiftTypes];
+
+    // 有効フィルター
+    if (showActiveOnly) {
+      filtered = filtered.filter((shiftType) => shiftType.isActive);
+    }
+
+    // 名前順でソート
+    filtered.sort((a, b) => {
+      // 有効なものが先に来るようにソート
+      if (a.isActive && !b.isActive) return -1;
+      if (!a.isActive && b.isActive) return 1;
+      // 名前でソート
+      return a.name.localeCompare(b.name, 'ja');
+    });
+
+    setFilteredShiftTypes(filtered);
+  }, [shiftTypes, showActiveOnly]);
+
+  const updateStats = useCallback(() => {
+    const total = filteredShiftTypes.length;
+    const active = filteredShiftTypes.filter((shiftType) => shiftType.isActive).length;
+
+    setStats({ total, active });
+  }, [filteredShiftTypes]);
+
+  // データ取得
+  useEffect(() => {
+    loadShiftTypes();
+  }, []);
+
+  // フィルター適用
+  useEffect(() => {
+    applyFilter();
+  }, [applyFilter]);
+
+  // 統計更新
+  useEffect(() => {
+    updateStats();
+  }, [updateStats]);
+
+  const handleActiveFilterChange = (checked: boolean) => {
+    setShowActiveOnly(checked);
+  };
+
+  const handleOpenModal = (shiftType?: ShiftType) => {
+    setEditingShiftType(shiftType || null);
+    setIsModalOpen(true);
+  };
+
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+    setEditingShiftType(null);
+  };
+
+  const handleSave = async (data: ShiftTypeFormData) => {
+    try {
+      if (editingShiftType) {
+        // 更新
+        const updated = await updateShiftType(editingShiftType.id, data);
+        setShiftTypes((prev) =>
+          prev.map((shiftType) => (shiftType.id === editingShiftType.id ? updated : shiftType))
+        );
+      } else {
+        // 新規作成
+        const created = await createShiftType(data);
+        setShiftTypes((prev) => [...prev, created]);
+      }
+
+      handleCloseModal();
+    } catch (error) {
+      throw error; // モーダル側でエラーハンドリング
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="mx-auto max-w-7xl px-4 py-4 sm:px-6 md:py-8 lg:px-8">
+        <div className="flex h-64 items-center justify-center">
+          <div className="text-center">
+            <div className="mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-4 border-primary-500 border-t-transparent"></div>
+            <p className="text-muted-foreground">データを読み込んでいます...</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="mx-auto max-w-7xl px-4 py-4 sm:px-6 md:py-8 lg:px-8">
+        <div className="flex h-64 items-center justify-center">
+          <div className="text-center">
+            <p className="mb-4 text-destructive">{error}</p>
+            <Button onClick={loadShiftTypes}>再試行</Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-4 sm:px-6 md:py-8 lg:px-8">
+      {/* ページタイトル */}
+      <div className="mb-6 md:mb-8">
+        <div className="flex flex-col md:flex-row md:items-center md:justify-between">
+          <div>
+            <h1 className="mb-2 text-2xl font-bold text-foreground md:text-3xl">シフト種類管理</h1>
+            <p className="text-sm text-muted-foreground md:text-base">
+              シフト種類の登録・管理を行います
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* 統計情報 */}
+      <div className="mb-4 md:mb-6">
+        <Card className="mx-auto w-full max-w-md md:mx-0">
+          <CardContent className="px-3 py-2">
+            <div className="flex items-center justify-center divide-x divide-border">
+              <div className="flex items-center gap-2 px-4 py-1">
+                <Tag className="h-4 w-4 text-primary" weight="regular" />
+                <div className="text-base font-bold text-primary">{stats.total}</div>
+                <span className="text-sm text-muted-foreground">合計</span>
+              </div>
+
+              <div className="flex items-center gap-2 px-4 py-1">
+                <SealCheck
+                  className="h-4 w-4 text-green-600 dark:text-green-400"
+                  weight="regular"
+                />
+                <div className="text-base font-bold text-green-600 dark:text-green-400">
+                  {stats.active}
+                </div>
+                <span className="text-sm text-muted-foreground">有効</span>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* シフト種類一覧テーブル */}
+      <div className="overflow-x-auto rounded-lg border bg-white shadow-lg dark:bg-gray-900">
+        <div className="space-y-4 border-b p-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold">シフト種類一覧</h2>
+            <Button onClick={() => handleOpenModal()} className="flex items-center gap-2">
+              <Plus className="h-4 w-4" weight="regular" />
+              追加
+            </Button>
+          </div>
+
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            {/* 有効のみスイッチ */}
+            <div className="flex items-center space-x-2">
+              <Switch
+                id="active-only"
+                checked={showActiveOnly}
+                onCheckedChange={handleActiveFilterChange}
+              />
+              <Label htmlFor="active-only" className="flex cursor-pointer items-center gap-1">
+                <SealCheck
+                  className="h-4 w-4 text-green-600 dark:text-green-400"
+                  weight="regular"
+                />
+                有効のみ
+              </Label>
+            </div>
+          </div>
+        </div>
+        <Table>
+          <TableHeader>
+            <TableRow className="bg-white dark:bg-gray-900">
+              <TableHead className="w-12"></TableHead>
+              <TableHead className="min-w-[200px]">シフト種類名</TableHead>
+              <TableHead className="w-24 text-center">状態</TableHead>
+              <TableHead className="hidden min-w-[150px] md:table-cell">作成日</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filteredShiftTypes.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={4} className="py-8 text-center text-muted-foreground">
+                  {showActiveOnly
+                    ? '有効なシフト種類がありません'
+                    : 'シフト種類が登録されていません'}
+                </TableCell>
+              </TableRow>
+            ) : (
+              filteredShiftTypes.map((shiftType) => (
+                <TableRow
+                  key={shiftType.id}
+                  className={`cursor-pointer transition-colors hover:bg-accent/50 ${
+                    !shiftType.isActive ? 'opacity-60' : ''
+                  }`}
+                  onClick={() => handleOpenModal(shiftType)}
+                >
+                  <TableCell>
+                    <Tag className="h-5 w-5 text-primary" weight="regular" />
+                  </TableCell>
+                  <TableCell>
+                    <span className={`font-medium ${!shiftType.isActive ? 'line-through' : ''}`}>
+                      {shiftType.name}
+                    </span>
+                  </TableCell>
+                  <TableCell className="text-center">
+                    <span
+                      className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-medium ${
+                        shiftType.isActive
+                          ? 'bg-green-100 text-green-800 dark:bg-green-900/20 dark:text-green-300'
+                          : 'bg-gray-100 text-gray-800 dark:bg-gray-900/20 dark:text-gray-400'
+                      }`}
+                    >
+                      {shiftType.isActive ? '有効' : '無効'}
+                    </span>
+                  </TableCell>
+                  <TableCell className="hidden text-sm text-muted-foreground md:table-cell">
+                    {new Date(shiftType.createdAt).toLocaleDateString('ja-JP')}
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* モーダル */}
+      <ShiftTypeModal
+        isOpen={isModalOpen}
+        onClose={handleCloseModal}
+        shiftType={editingShiftType}
+        onSave={handleSave}
+      />
+    </div>
+  );
+}

--- a/app/admin/shift-types/types.ts
+++ b/app/admin/shift-types/types.ts
@@ -1,0 +1,20 @@
+import type { ShiftType } from '@prisma/client';
+
+export interface ShiftTypeStats {
+  total: number;
+  active: number;
+}
+
+export interface ShiftTypeFormData {
+  name: string;
+  isActive: boolean;
+}
+
+export interface ShiftTypeModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  shiftType?: ShiftType | null;
+  onSave: (data: ShiftTypeFormData) => Promise<void>;
+}
+
+export type { ShiftType };

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Snowflake, CalendarDots, Certificate, UsersThree, List } from '@phosphor-icons/react';
+import { Snowflake, CalendarDots, Certificate, UsersThree, List, Tag } from '@phosphor-icons/react';
 import { Sheet, SheetContent, SheetTrigger, SheetTitle } from '@/components/ui/sheet';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { useState } from 'react';
@@ -23,6 +23,11 @@ export default function Header() {
       href: '/admin/instructors',
       icon: UsersThree,
       label: 'インストラクター管理',
+    },
+    {
+      href: '/admin/shift-types',
+      icon: Tag,
+      label: 'シフト種類管理',
     },
     {
       href: '/admin/certifications',


### PR DESCRIPTION
## 概要

スキー・スノーボードスクールのシフトタイプ管理機能を追加し、GitHub MCP設定を最新化しました。

## 変更内容

### ✨ 新機能
- **シフトタイプ管理機能を追加**
  - シフトタイプの作成・編集・削除機能
  - シフトスケジュールでのタイプ別管理
  - データベーススキーマの拡張

### 🔧 設定改善
- **GitHub MCP設定の最新化**
  - 環境変数名を`GITHUB_TOKEN`に統一
  - 最新のGitHub公式MCPサーバー(`ghcr.io/github/github-mcp-server`)を使用
  - Docker環境変数の読み込み方法を改善(`--env-file`使用)

## 技術的詳細

- Next.js 15.4 + TypeScript 5.8
- Prisma ORM 6.12 + Cloudflare D1
- Tailwind CSS 4.1

## テスト

- 型チェック: `npm run typecheck` ✅
- Lint: `npm run lint` ✅

## 関連コミット

- `fa263ad` ✨ Add shift type management feature
- `64ee10e` 🔧 Update GitHub MCP configuration