### PR TITLE
🔧 Remove context7 and serena MCP servers from configuration

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,23 +1,5 @@
 {
   "mcpServers": {
-    "context7": {
-      "command": "npx",
-      "args": ["-y", "@upstash/context7-mcp@latest"]
-    },
-    "serena": {
-      "command": "uvx",
-      "args": [
-        "--from",
-        "git+https://github.com/oraios/serena",
-        "serena",
-        "start-mcp-server",
-        "--context",
-        "ide-assistant",
-        "--project",
-        "."
-      ],
-      "cwd": "."
-    },
     "container-use": {
       "command": "container-use",
       "args": ["stdio"]


### PR DESCRIPTION
## 概要
context7とserenaMCPサーバーの設定を.mcp.jsonから削除しました。

## 変更内容
- ❌ context7: npxによる@upstash/context7-mcp設定を削除
- ❌ serena: uvxによるserena MCP サーバー設定を削除  
- ✅ container-use: 既存設定はそのまま維持
- ✅ github: 既存設定はそのまま維持

## 変更理由
不要なMCPサーバー設定を削除してシンプルな構成にするため

## テスト手順
- [ ] .mcp.jsonの設定が正しく削除されていることを確認
- [ ] container-useとgithub MCPサーバーが正常に動作することを確認