### PR TITLE
🚀 Fix Cloudflare Workers compatibility for deployment

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,6 @@
 name = "snow-school-scheduler"
 main = ".open-next/worker.js"
-compatibility_date = "2024-09-16"
+compatibility_date = "2024-09-23"
 compatibility_flags = ["nodejs_compat"]
 
 # D1データベースバインディング


### PR DESCRIPTION
## 概要

Cloudflare Workersでのデプロイエラーを修正。Node.js組み込みモジュールの解決問題に対応。

## 変更内容

- [x] バグ修正
- [x] 設定変更

## やったこと

- wrangler.tomlのcompatibility_dateを2024-09-16から2024-09-23に更新
- Node.js組み込みモジュール（async_hooks, fs等）の解決エラーを修正
- Cloudflare Workers 2024-09-23互換性に対応

## やらないこと

- OpenNext生成コードの手動変更（自動生成のため不要）
- その他の設定項目の変更

## 動作確認

- [x] ローカル環境での動作確認完了
- [x] TypeScriptの型チェック通過 (`npm run typecheck`)
- [x] ESLintチェック通過 (`npm run lint`)
- [ ] テスト実行完了 (`npm test`)
- [ ] ビルド確認完了 (`npm run build`)

## 関連Issue

デプロイエラー: https://github.com/keichan110/snow-school-scheduler/actions/runs/17833147791/job/50703279627

## レビューポイント

- wrangler.tomlのcompatibility_date変更の妥当性
- Cloudflare Workers互換性設定の適切性

## 備考

- Cloudflareの公式推奨に従った修正
- 2024-09-23以降のcompatibility_dateでNode.js組み込みモジュールが正しく解決される