### PR TITLE
🐛 Fix D1 database_id configuration for deployment

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -7,7 +7,7 @@ compatibility_flags = ["nodejs_compat"]
 [[d1_databases]]
 binding = "DB"
 database_name = "snow-school-scheduler"
-database_id = "ia39eae08-e034-45a3-b85a-d7e9d1b57c30"
+database_id = "a39eae08-e034-45a3-b85a-d7e9d1b57c30"
 
 # 環境変数（非機密情報のみ）
 [vars]


### PR DESCRIPTION
# プルリクエストテンプレート

## 概要

Cloudflare WorkersデプロイエラーでD1データベースのdatabase_id設定に不正な文字が含まれていた問題を修正。正しいUUIDに修正してデプロイを成功させる。

## 変更内容

- [x] バグ修正
- [x] 設定変更
- [ ] 新機能追加
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] テスト追加・修正
- [ ] その他:

## やったこと

- wrangler.tomlのdatabase_idから不正な先頭文字'i'を削除
- CloudflareのD1データベース一覧で確認した正しいUUIDに修正
- エラーメッセージ「You must use a real database in the database_id configuration」を解決

## やらないこと

- データベーススキーマの変更
- 他のwrangler.toml設定の変更
- D1データベース自体の再作成

## 動作確認

- [x] ローカル環境での動作確認完了
- [x] TypeScriptの型チェック通過 (`npm run typecheck`)
- [x] ESLintチェック通過 (`npm run lint`)
- [ ] テスト実行完了 (`npm test`) - 設定変更のためスキップ
- [ ] ビルド確認完了 (`npm run build`) - デプロイで確認予定

## 関連Issue

GitHub Actions デプロイエラー: https://github.com/keichan110/snow-school-scheduler/actions/runs/17857969332/job/50781338274

エラーメッセージ:
```
You must use a real database in the database_id configuration. 
You can find your databases using 'wrangler d1 list'
```

## スクリーンショット・動画

設定変更のため該当なし

## レビューポイント

- database_idの修正内容が正しいか（先頭の'i'削除）
- D1データベース一覧との整合性確認
- 他のCloudflare設定への影響がないか

## 備考

- `wrangler d1 list`で確認した正しいUUID: `a39eae08-e034-45a3-b85a-d7e9d1b57c30`
- 修正前の不正なID: `ia39eae08-e034-45a3-b85a-d7e9d1b57c30`（先頭に'i'が誤って含まれていた）
- この修正によりCloudflare Workersデプロイが正常に動作する見込み
- デプロイ成功後、ヘルスチェックの再有効化も予定