### PR TITLE
🐛 Fix D1 migrations path for Cloudflare deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,6 +50,16 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: deploy
 
+      - name: Prepare D1 migrations
+        run: |
+          mkdir -p migrations
+          if [ -d "prisma/migrations" ]; then
+            find prisma/migrations -name "migration.sql" -exec cp {} migrations/ \;
+            echo "Copied Prisma migrations to D1 migrations directory"
+          else
+            echo "No Prisma migrations found"
+          fi
+
       - name: Apply D1 database migrations
         uses: cloudflare/wrangler-action@v3
         with:


### PR DESCRIPTION
# プルリクエストテンプレート

## 概要

GitHub Actions環境でCloudflare D1マイグレーション適用時の「No migrations present」エラーを修正。PrismaマイグレーションファイルをwranglerD1用のディレクトリにコピーする処理を追加。

## 変更内容

- [x] バグ修正
- [x] 設定変更
- [ ] 新機能追加
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] テスト追加・修正
- [ ] その他:

## やったこと

- GitHub Actionsワークフローに「Prepare D1 migrations」ステップを追加
- prisma/migrationsディレクトリから./migrationsディレクトリへのコピー処理を実装
- 安全性のためのディレクトリ存在チェックとエラーハンドリングを追加
- wranglerがデフォルトで探すパス（./migrations）に対応

## やらないこと

- Prismaマイグレーション自体の変更
- データベーススキーマの修正
- wrangler.tomlの他の設定変更
- マイグレーションファイルの内容変更

## 動作確認

- [x] ローカル環境での動作確認完了
- [x] TypeScriptの型チェック通過 (`npm run typecheck`)
- [x] ESLintチェック通過 (`npm run lint`)
- [ ] テスト実行完了 (`npm test`) - ワークフロー変更のためスキップ
- [ ] ビルド確認完了 (`npm run build`) - デプロイで確認予定

## 関連Issue

GitHub Actions D1マイグレーションエラー

エラーメッセージ:
```
No migrations present at /home/runner/work/snow-school-scheduler/snow-school-scheduler/migrations.
```

## スクリーンショット・動画

ワークフロー変更のため該当なし

## レビューポイント

- マイグレーションファイルのコピー処理が適切か
- エラーハンドリングの実装が十分か
- wranglerとPrismaのマイグレーション形式の互換性確認
- GitHub Actions環境でのパス処理が正しいか

## 備考

- wranglerはデフォルトで`./migrations`ディレクトリを探すが、Prismaは`./prisma/migrations`を使用
- `find`コマンドでmigration.sqlファイルのみを抽出してコピー
- 既存のPR #69（database_id修正）と組み合わせることで完全なデプロイ修正となる
- この修正によりD1データベースマイグレーションが正常に適用される見込み
- デプロイ成功後、ヘルスチェックの再有効化も予定