### PR TITLE
🔧 Use NEXTAUTH_URL for health check endpoint

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,12 +80,14 @@ jobs:
 
     steps:
       - name: Health check
+        env:
+          NEXTAUTH_URL: ${{ secrets.NEXTAUTH_URL }}
         run: |
           echo "Waiting for deployment to be available..."
           sleep 30
 
           # ヘルスチェックAPI呼び出し
-          RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" https://snow-school-scheduler.YOUR_SUBDOMAIN.workers.dev/api/health)
+          RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" ${NEXTAUTH_URL}/api/health)
 
           if [ "$RESPONSE" = "200" ]; then
             echo "✅ Health check passed! Application is running correctly."


### PR DESCRIPTION
# プルリクエストテンプレート

## 概要

GitHub ActionsのヘルスチェックステップでハードコードされたプレースホルダーURLを既存のNEXTAUTH_URLシークレットを使用した動的URLに変更。新しい環境変数を追加せずにヘルスチェック機能を完成させる。

## 変更内容

- [x] バグ修正
- [x] 設定変更
- [ ] 新機能追加
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] テスト追加・修正
- [ ] その他:

## やったこと

- ヘルスチェックステップにNEXTAUTH_URL環境変数を追加
- ハードコードされたプレースホルダーURL `YOUR_SUBDOMAIN` を `${NEXTAUTH_URL}` に変更
- 既存のGitHub Secretsを活用した動的URL参照を実現
- 新しい環境変数追加を回避してシンプルな実装を維持

## やらないこと

- 新しいGitHub Secretsの追加
- ヘルスチェック機能の無効化
- 他のワークフロー設定の変更
- ハードコードされた別のURLへの変更

## 動作確認

- [x] ローカル環境での動作確認完了
- [x] TypeScriptの型チェック通過 (`npm run typecheck`)
- [x] ESLintチェック通過 (`npm run lint`)
- [ ] テスト実行完了 (`npm test`) - ワークフロー変更のためスキップ
- [ ] ビルド確認完了 (`npm run build`) - デプロイで確認予定

## 関連Issue

GitHub Actionsヘルスチェックで古いプレースホルダーURLが参照される問題

修正前の問題箇所:
```yaml
RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" https://snow-school-scheduler.YOUR_SUBDOMAIN.workers.dev/api/health)
```

## スクリーンショット・動画

ワークフロー変更のため該当なし

## レビューポイント

- NEXTAUTH_URLの環境変数設定が適切か
- GitHub Secretsの参照方法が正しいか
- ヘルスチェックURLの構成が妥当か
- 既存のシークレット活用によるシンプルさの維持

## 備考

- 既存のNEXTAUTH_URLシークレットを活用することで追加設定が不要
- GitHub Secretsでの値更新時に自動的にヘルスチェックも追従
- PR #69（database_id修正）、PR #70（migrations修正）と組み合わせて完全なデプロイ修正となる
- この修正により認証とヘルスチェックで一貫したベースURLを使用
- デプロイ成功後、ヘルスチェックが正常に動作する見込み