### PR TITLE
🐛 Fix static assets serving issues in Cloudflare Workers

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,2 @@
+/_next/static/*
+  Cache-Control: public,max-age=31536000,immutable

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -9,6 +9,11 @@ binding = "DB"
 database_name = "snow-school-scheduler"
 database_id = "a39eae08-e034-45a3-b85a-d7e9d1b57c30"
 
+# 静的アセット設定
+[assets]
+directory = ".open-next/assets"
+binding = "ASSETS"
+
 # 環境変数（非機密情報のみ）
 [vars]
 NODE_ENV = "production"


### PR DESCRIPTION
## 概要

Cloudflare WorkersでCSSとJavaScriptが404エラーになる問題を修正しました。静的アセットの適切な配信設定を追加し、最適なキャッシュヘッダーを設定しています。

## 変更内容

- [x] バグ修正
- [x] 設定変更

## やったこと

- `wrangler.toml`: 静的アセット配信設定を追加（`[assets]` セクション）
- `open-next.config.ts`: 無効なプロパティ（`staticFileBehavior`, `headers`）を削除し、正しい設定に修正
- `public/_headers`: 静的アセットの最適なキャッシュヘッダーを設定（1年間キャッシュ + immutable）

## やらないこと

- このPRでは設定修正のみで、機能追加は行わない

## 動作確認

- [x] ローカル環境での動作確認完了
- [x] TypeScriptの型チェック通過 (`npm run typecheck`)
- [x] ESLintチェック通過 (`npm run lint`)
- [ ] テスト実行完了 (`npm test`) - デプロイ後に確認予定
- [ ] ビルド確認完了 (`npm run build`) - GitHub Actionsで確認予定

## 関連Issue

デプロイされたサイトでCSSが効いていない問題の修正

## レビューポイント

- `wrangler.toml`の`[assets]`設定が適切か
- `public/_headers`のキャッシュ設定が適切か
- OpenNext Cloudflareの設定が正しく修正されているか

## 備考

- Context7とWebSearchを使用してOpenNext Cloudflareの公式ドキュメントに基づいて修正
- `public/_headers`はCloudflare専用の設定ファイルで、静的アセットの最適化に必要