### PR TITLE
Harden public auth rate limiting

### DIFF
--- a/app/api/auth/me/route.ts
+++ b/app/api/auth/me/route.ts
@@ -226,17 +226,25 @@ export async function POST(request: NextRequest) {
   }
 }
 
-/**
- * OPTIONS /api/auth/me
- * CORS対応
- */
-export async function OPTIONS() {
+export async function OPTIONS(request: NextRequest) {
+  const origin = request.headers.get('origin');
+  const allowedOrigins = [
+    process.env.NEXT_PUBLIC_APP_URL,
+    'http://localhost:3000',
+    'https://localhost:3000',
+  ].filter(Boolean); // undefined環境変数を除去
+
+  if (!origin || !allowedOrigins.includes(origin)) {
+    return new NextResponse(null, { status: 403 });
+  }
+
   return new NextResponse(null, {
     status: 200,
     headers: {
-      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Origin': origin,
       'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
       'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+      'Access-Control-Allow-Credentials': 'true',
     },
   });
 }

--- a/app/api/certifications/[id]/route.test.ts
+++ b/app/api/certifications/[id]/route.test.ts
@@ -1,26 +1,7 @@
 import { GET, PUT } from './route';
 import { prisma } from '@/lib/db';
-import { NextResponse } from 'next/server';
-
-// Request グローバルオブジェクトのモック
-global.Request = class MockRequest {
-  url: string;
-  method: string;
-  private _body: unknown;
-
-  constructor(url: string, options?: { method?: string; body?: unknown }) {
-    this.url = url;
-    this.method = options?.method || 'GET';
-    this._body = options?.body;
-  }
-
-  async json(): Promise<unknown> {
-    if (typeof this._body === 'string') {
-      return JSON.parse(this._body);
-    }
-    return this._body || {};
-  }
-} as unknown as typeof Request;
+import { NextRequest, NextResponse } from 'next/server';
+import { authenticateFromRequest } from '@/lib/auth/middleware';
 
 // Prismaクライアントをモック化
 jest.mock('@/lib/db', () => ({
@@ -39,6 +20,11 @@ jest.mock('next/server', () => ({
   },
 }));
 
+// 認証ミドルウェアをモック化
+jest.mock('@/lib/auth/middleware', () => ({
+  authenticateFromRequest: jest.fn(),
+}));
+
 const mockPrisma = prisma as jest.Mocked<typeof prisma>;
 const mockCertificationFindUnique = mockPrisma.certification.findUnique as jest.MockedFunction<
   typeof prisma.certification.findUnique
@@ -47,10 +33,26 @@ const mockCertificationUpdate = mockPrisma.certification.update as jest.MockedFu
   typeof prisma.certification.update
 >;
 const mockNextResponse = NextResponse as jest.Mocked<typeof NextResponse>;
+const mockAuthenticateFromRequest = authenticateFromRequest as jest.MockedFunction<
+  typeof authenticateFromRequest
+>;
 
 describe('GET /api/certifications/[id]', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // 認証成功をデフォルトでモック
+    mockAuthenticateFromRequest.mockResolvedValue({
+      success: true,
+      user: {
+        id: '1',
+        lineUserId: 'test-user',
+        displayName: 'Test User',
+        role: 'ADMIN',
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
     // NextResponse.jsonのデフォルトモック実装
     mockNextResponse.json.mockImplementation((data, init) => {
       return {
@@ -150,7 +152,7 @@ describe('GET /api/certifications/[id]', () => {
       };
 
       // Act
-      await GET(new Request('http://localhost'), mockContext);
+      await GET(new NextRequest('http://localhost'), mockContext);
 
       // Assert
       expect(mockCertificationFindUnique).toHaveBeenCalledWith({
@@ -228,7 +230,7 @@ describe('GET /api/certifications/[id]', () => {
       };
 
       // Act
-      await GET(new Request('http://localhost'), mockContext);
+      await GET(new NextRequest('http://localhost'), mockContext);
 
       // Assert
       expect(mockNextResponse.json).toHaveBeenCalledWith({
@@ -250,7 +252,7 @@ describe('GET /api/certifications/[id]', () => {
       };
 
       // Act
-      await GET(new Request('http://localhost'), mockContext);
+      await GET(new NextRequest('http://localhost'), mockContext);
 
       // Assert
       expect(mockCertificationFindUnique).toHaveBeenCalledWith({
@@ -295,7 +297,7 @@ describe('GET /api/certifications/[id]', () => {
       };
 
       // Act
-      await GET(new Request('http://localhost'), mockContext);
+      await GET(new NextRequest('http://localhost'), mockContext);
 
       // Assert
       expect(mockCertificationFindUnique).not.toHaveBeenCalled();
@@ -323,7 +325,7 @@ describe('GET /api/certifications/[id]', () => {
       };
 
       // Act
-      await GET(new Request('http://localhost'), mockContext);
+      await GET(new NextRequest('http://localhost'), mockContext);
 
       // Assert
       expect(mockCertificationFindUnique).toHaveBeenCalledWith({
@@ -389,7 +391,7 @@ describe('GET /api/certifications/[id]', () => {
       };
 
       // Act
-      await GET(new Request('http://localhost'), mockContext);
+      await GET(new NextRequest('http://localhost'), mockContext);
 
       // Assert
       expect(mockCertificationFindUnique).toHaveBeenCalledWith({
@@ -426,7 +428,7 @@ describe('GET /api/certifications/[id]', () => {
       };
 
       // Act
-      await GET(new Request('http://localhost'), mockContext);
+      await GET(new NextRequest('http://localhost'), mockContext);
 
       // Assert
       expect(mockCertificationFindUnique).toHaveBeenCalledTimes(1);
@@ -441,7 +443,7 @@ describe('GET /api/certifications/[id]', () => {
       };
 
       // Act
-      await GET(new Request('http://localhost'), mockContext);
+      await GET(new NextRequest('http://localhost'), mockContext);
 
       // Assert
       expect(mockCertificationFindUnique).toHaveBeenCalledWith(
@@ -476,10 +478,23 @@ describe('PUT /api/certifications/[id]', () => {
   // NextRequest.jsonをモック化
   const mockRequest = {
     json: jest.fn(),
-  } as unknown as Request;
+  } as unknown as NextRequest;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // 認証成功をデフォルトでモック
+    mockAuthenticateFromRequest.mockResolvedValue({
+      success: true,
+      user: {
+        id: '1',
+        lineUserId: 'test-user',
+        displayName: 'Test User',
+        role: 'ADMIN',
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
     // NextResponse.jsonのデフォルトモック実装
     mockNextResponse.json.mockImplementation((data, init) => {
       return {

--- a/app/api/certifications/[id]/route.test.ts
+++ b/app/api/certifications/[id]/route.test.ts
@@ -13,11 +13,25 @@ jest.mock('@/lib/db', () => ({
   },
 }));
 
-// NextResponseをモック化
+// NextResponseとNextRequestをモック化
 jest.mock('next/server', () => ({
   NextResponse: {
     json: jest.fn(),
   },
+  NextRequest: jest.fn((url, init) => ({
+    url,
+    ...init,
+    headers: new Headers(init?.headers),
+    cookies: {
+      get: jest.fn().mockReturnValue({ value: 'test-token' }),
+    },
+    json: init?.body
+      ? () => Promise.resolve(JSON.parse(init.body as string))
+      : () => Promise.resolve({}),
+    nextUrl: {
+      searchParams: new URL(url as string).searchParams,
+    },
+  })),
 }));
 
 // 認証ミドルウェアをモック化

--- a/app/api/certifications/[id]/route.ts
+++ b/app/api/certifications/[id]/route.ts
@@ -1,11 +1,12 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
+import { authenticateFromRequest } from '@/lib/auth/middleware';
 
 interface RouteContext {
   params: Promise<{ id: string }>;
 }
 
-export async function GET(request: Request, context: RouteContext) {
+export async function GET(request: NextRequest, context: RouteContext) {
   try {
     const { id } = await context.params;
 
@@ -87,7 +88,19 @@ export async function GET(request: Request, context: RouteContext) {
   }
 }
 
-export async function PUT(request: Request, context: RouteContext) {
+export async function PUT(request: NextRequest, context: RouteContext) {
+  const authResult = await authenticateFromRequest(request);
+  if (!authResult.success) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Authentication required',
+        data: null,
+        message: null,
+      },
+      { status: 401 }
+    );
+  }
   try {
     const { id } = await context.params;
 

--- a/app/api/certifications/route.test.ts
+++ b/app/api/certifications/route.test.ts
@@ -29,11 +29,25 @@ jest.mock('@/lib/db', () => ({
   },
 }));
 
-// NextResponseをモック化
+// NextResponseとNextRequestをモック化
 jest.mock('next/server', () => ({
   NextResponse: {
     json: jest.fn(),
   },
+  NextRequest: jest.fn((url, init) => ({
+    url,
+    ...init,
+    headers: new Headers(init?.headers),
+    cookies: {
+      get: jest.fn().mockReturnValue({ value: 'test-token' }),
+    },
+    json: init?.body
+      ? () => Promise.resolve(JSON.parse(init.body as string))
+      : () => Promise.resolve({}),
+    nextUrl: {
+      searchParams: new URL(url as string).searchParams,
+    },
+  })),
 }));
 
 // 認証ミドルウェアをモック化

--- a/app/api/certifications/route.test.ts
+++ b/app/api/certifications/route.test.ts
@@ -60,7 +60,7 @@ describe('GET /api/certifications', () => {
     mockAuthenticateFromRequest.mockResolvedValue({
       success: true,
       user: {
-        id: 1,
+        id: '1',
         lineUserId: 'test-line-user',
         displayName: 'Test User',
         profileImageUrl: null,
@@ -133,7 +133,7 @@ describe('GET /api/certifications', () => {
       mockCertificationFindMany.mockResolvedValue(mockCertifications);
 
       // Act
-      await GET();
+      await GET(new NextRequest('http://localhost'));
 
       // Assert
       expect(mockCertificationFindMany).toHaveBeenCalledWith({
@@ -163,7 +163,7 @@ describe('GET /api/certifications', () => {
       mockCertificationFindMany.mockResolvedValue(mockCertifications);
 
       // Act
-      await GET();
+      await GET(new NextRequest('http://localhost'));
 
       // Assert
       expect(mockCertificationFindMany).toHaveBeenCalledWith({
@@ -210,7 +210,7 @@ describe('GET /api/certifications', () => {
       mockCertificationFindMany.mockResolvedValue(mockCertifications);
 
       // Act
-      await GET();
+      await GET(new NextRequest('http://localhost'));
 
       // Assert
       expect(mockNextResponse.json).toHaveBeenCalledWith({
@@ -233,7 +233,7 @@ describe('GET /api/certifications', () => {
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
 
       // Act
-      await GET();
+      await GET(new NextRequest('http://localhost'));
 
       // Assert
       expect(mockCertificationFindMany).toHaveBeenCalledWith({
@@ -273,7 +273,7 @@ describe('GET /api/certifications', () => {
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
 
       // Act
-      await GET();
+      await GET(new NextRequest('http://localhost'));
 
       // Assert
       expect(consoleSpy).toHaveBeenCalledWith('Certifications API error:', mockError);
@@ -310,7 +310,7 @@ describe('GET /api/certifications', () => {
       mockCertificationFindMany.mockResolvedValue(mockCertifications as Certification[]);
 
       // Act
-      await GET();
+      await GET(new NextRequest('http://localhost'));
 
       // Assert
       expect(mockCertificationFindMany).toHaveBeenCalledWith({
@@ -331,7 +331,7 @@ describe('GET /api/certifications', () => {
       mockCertificationFindMany.mockResolvedValue([]);
 
       // Act
-      await GET();
+      await GET(new NextRequest('http://localhost'));
 
       // Assert
       expect(mockCertificationFindMany).toHaveBeenCalledTimes(1);
@@ -342,7 +342,7 @@ describe('GET /api/certifications', () => {
       mockCertificationFindMany.mockResolvedValue([]);
 
       // Act
-      await GET();
+      await GET(new NextRequest('http://localhost'));
 
       // Assert
       expect(mockCertificationFindMany).toHaveBeenCalledWith(
@@ -369,6 +369,20 @@ describe('POST /api/certifications', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // 認証成功をデフォルトでモック
+    mockAuthenticateFromRequest.mockResolvedValue({
+      success: true,
+      user: {
+        id: '1',
+        lineUserId: 'test-line-user',
+        displayName: 'Test User',
+        profileImageUrl: null,
+        role: 'ADMIN',
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
     // NextResponse.jsonのデフォルトモック実装
     mockNextResponse.json.mockImplementation((data, init) => {
       return {

--- a/app/api/certifications/route.ts
+++ b/app/api/certifications/route.ts
@@ -1,7 +1,20 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
+import { authenticateFromRequest } from '@/lib/auth/middleware';
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const authResult = await authenticateFromRequest(request);
+  if (!authResult.success) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Authentication required',
+        data: null,
+        message: null,
+      },
+      { status: 401 }
+    );
+  }
   try {
     const certifications = await prisma.certification.findMany({
       include: {

--- a/app/api/certifications/route.ts
+++ b/app/api/certifications/route.ts
@@ -49,7 +49,20 @@ export async function GET(request: NextRequest) {
   }
 }
 
-export async function POST(request: Request) {
+export async function POST(request: NextRequest) {
+  const authResult = await authenticateFromRequest(request);
+  if (!authResult.success) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Authentication required',
+        data: null,
+        message: null,
+      },
+      { status: 401 }
+    );
+  }
+
   try {
     const body = await request.json();
 

--- a/app/api/departments/[id]/route.ts
+++ b/app/api/departments/[id]/route.ts
@@ -1,7 +1,21 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
+import { authenticateFromRequest } from '@/lib/auth/middleware';
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const authResult = await authenticateFromRequest(request);
+  if (!authResult.success) {
+    return NextResponse.json(
+      {
+        success: false,
+        data: null,
+        message: null,
+        error: 'Authentication required',
+      },
+      { status: 401 }
+    );
+  }
+
   try {
     // パラメータを解決
     const resolvedParams = await params;

--- a/app/api/departments/route.test.ts
+++ b/app/api/departments/route.test.ts
@@ -1,6 +1,6 @@
 import { GET } from './route';
 import { prisma } from '@/lib/db';
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
 type Department = {
   id: number;
@@ -88,7 +88,7 @@ describe('GET /api/departments', () => {
       mockDepartmentFindMany.mockResolvedValue(mockDepartments);
 
       // Act
-      await GET();
+      await GET(new NextRequest('http://localhost'));
 
       // Assert
       expect(mockDepartmentFindMany).toHaveBeenCalledWith({
@@ -112,7 +112,7 @@ describe('GET /api/departments', () => {
       mockDepartmentFindMany.mockResolvedValue(mockDepartments);
 
       // Act
-      await GET();
+      await GET(new NextRequest('http://localhost'));
 
       // Assert
       expect(mockDepartmentFindMany).toHaveBeenCalledWith({
@@ -147,7 +147,7 @@ describe('GET /api/departments', () => {
       mockDepartmentFindMany.mockResolvedValue(mockDepartments);
 
       // Act
-      await GET();
+      await GET(new NextRequest('http://localhost'));
 
       // Assert
       expect(mockNextResponse.json).toHaveBeenCalledWith({
@@ -170,7 +170,7 @@ describe('GET /api/departments', () => {
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
 
       // Act
-      await GET();
+      await GET(new NextRequest('http://localhost'));
 
       // Assert
       expect(mockDepartmentFindMany).toHaveBeenCalledWith({
@@ -204,7 +204,7 @@ describe('GET /api/departments', () => {
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
 
       // Act
-      await GET();
+      await GET(new NextRequest('http://localhost'));
 
       // Assert
       expect(consoleSpy).toHaveBeenCalledWith('Departments API error:', mockError);
@@ -233,7 +233,7 @@ describe('GET /api/departments', () => {
       mockDepartmentFindMany.mockResolvedValue(mockDepartments as Department[]);
 
       // Act
-      await GET();
+      await GET(new NextRequest('http://localhost'));
 
       // Assert
       expect(mockDepartmentFindMany).toHaveBeenCalledWith({
@@ -248,7 +248,7 @@ describe('GET /api/departments', () => {
       mockDepartmentFindMany.mockResolvedValue([]);
 
       // Act
-      await GET();
+      await GET(new NextRequest('http://localhost'));
 
       // Assert
       expect(mockDepartmentFindMany).toHaveBeenCalledTimes(1);

--- a/app/api/departments/route.ts
+++ b/app/api/departments/route.ts
@@ -1,7 +1,20 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
+import { authenticateFromRequest } from '@/lib/auth/middleware';
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const authResult = await authenticateFromRequest(request);
+  if (!authResult.success) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Authentication required',
+        data: null,
+        message: null,
+      },
+      { status: 401 }
+    );
+  }
   try {
     const departments = await prisma.department.findMany({
       orderBy: {

--- a/app/api/instructors/[id]/route.test.ts
+++ b/app/api/instructors/[id]/route.test.ts
@@ -1,27 +1,8 @@
 import { GET, PUT } from './route';
 import { prisma } from '@/lib/db';
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { InstructorStatus } from '@/shared/types/common';
-
-// Request グローバルオブジェクトのモック
-global.Request = class MockRequest {
-  url: string;
-  method: string;
-  private _body: unknown;
-
-  constructor(url: string, options?: { method?: string; body?: unknown }) {
-    this.url = url;
-    this.method = options?.method || 'GET';
-    this._body = options?.body;
-  }
-
-  async json(): Promise<unknown> {
-    if (typeof this._body === 'string') {
-      return JSON.parse(this._body);
-    }
-    return this._body || {};
-  }
-} as unknown as typeof Request;
+import { authenticateFromRequest } from '@/lib/auth/middleware';
 
 type InstructorWithCertifications = {
   id: number;
@@ -72,6 +53,11 @@ jest.mock('next/server', () => ({
   },
 }));
 
+// 認証ミドルウェアをモック化
+jest.mock('@/lib/auth/middleware', () => ({
+  authenticateFromRequest: jest.fn(),
+}));
+
 const mockPrisma = prisma as jest.Mocked<typeof prisma>;
 const mockInstructorFindUnique = mockPrisma.instructor.findUnique as jest.MockedFunction<
   typeof prisma.instructor.findUnique
@@ -88,6 +74,9 @@ const mockInstructorCertificationCreateMany = mockPrisma.instructorCertification
   .createMany as jest.MockedFunction<typeof prisma.instructorCertification.createMany>;
 const mockTransaction = mockPrisma.$transaction as jest.MockedFunction<typeof prisma.$transaction>;
 const mockNextResponse = NextResponse as jest.Mocked<typeof NextResponse>;
+const mockAuthenticateFromRequest = authenticateFromRequest as jest.MockedFunction<
+  typeof authenticateFromRequest
+>;
 
 describe('GET /api/instructors/[id]', () => {
   beforeEach(() => {
@@ -159,7 +148,7 @@ describe('GET /api/instructors/[id]', () => {
 
       mockInstructorFindUnique.mockResolvedValue(mockInstructor);
 
-      const mockRequest = new Request('http://localhost:3000/api/instructors/1');
+      const mockRequest = new NextRequest('http://localhost:3000/api/instructors/1');
       const context = { params: Promise.resolve({ id: '1' }) };
 
       // Act
@@ -243,7 +232,7 @@ describe('GET /api/instructors/[id]', () => {
 
       mockInstructorFindUnique.mockResolvedValue(mockInstructor);
 
-      const mockRequest = new Request('http://localhost:3000/api/instructors/2');
+      const mockRequest = new NextRequest('http://localhost:3000/api/instructors/2');
       const context = { params: Promise.resolve({ id: '2' }) };
 
       // Act
@@ -286,7 +275,7 @@ describe('GET /api/instructors/[id]', () => {
 
       mockInstructorFindUnique.mockResolvedValue(mockInstructor);
 
-      const mockRequest = new Request('http://localhost:3000/api/instructors/123');
+      const mockRequest = new NextRequest('http://localhost:3000/api/instructors/123');
       const context = { params: Promise.resolve({ id: '123' }) };
 
       // Act
@@ -320,7 +309,7 @@ describe('GET /api/instructors/[id]', () => {
       // Arrange
       mockInstructorFindUnique.mockResolvedValue(null);
 
-      const mockRequest = new Request('http://localhost:3000/api/instructors/999');
+      const mockRequest = new NextRequest('http://localhost:3000/api/instructors/999');
       const context = { params: Promise.resolve({ id: '999' }) };
 
       // Act
@@ -360,7 +349,7 @@ describe('GET /api/instructors/[id]', () => {
 
     it('無効なID（数値でない）が指定された場合に400エラーが返されること', async () => {
       // Arrange
-      const mockRequest = new Request('http://localhost:3000/api/instructors/invalid');
+      const mockRequest = new NextRequest('http://localhost:3000/api/instructors/invalid');
       const context = { params: Promise.resolve({ id: 'invalid' }) };
 
       // Act
@@ -381,7 +370,7 @@ describe('GET /api/instructors/[id]', () => {
 
     it('負の数値IDが指定された場合に400エラーが返されること', async () => {
       // Arrange
-      const mockRequest = new Request('http://localhost:3000/api/instructors/-1');
+      const mockRequest = new NextRequest('http://localhost:3000/api/instructors/-1');
       const context = { params: Promise.resolve({ id: '-1' }) };
 
       // Act
@@ -402,7 +391,7 @@ describe('GET /api/instructors/[id]', () => {
 
     it('0のIDが指定された場合に400エラーが返されること', async () => {
       // Arrange
-      const mockRequest = new Request('http://localhost:3000/api/instructors/0');
+      const mockRequest = new NextRequest('http://localhost:3000/api/instructors/0');
       const context = { params: Promise.resolve({ id: '0' }) };
 
       // Act
@@ -427,7 +416,7 @@ describe('GET /api/instructors/[id]', () => {
       mockInstructorFindUnique.mockRejectedValue(mockError);
 
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
-      const mockRequest = new Request('http://localhost:3000/api/instructors/1');
+      const mockRequest = new NextRequest('http://localhost:3000/api/instructors/1');
       const context = { params: Promise.resolve({ id: '1' }) };
 
       // Act
@@ -468,7 +457,7 @@ describe('GET /api/instructors/[id]', () => {
 
       mockInstructorFindUnique.mockResolvedValue(mockInstructor);
 
-      const mockRequest = new Request('http://localhost:3000/api/instructors/1');
+      const mockRequest = new NextRequest('http://localhost:3000/api/instructors/1');
       const context = { params: Promise.resolve({ id: '1' }) };
 
       // Act
@@ -482,7 +471,7 @@ describe('GET /api/instructors/[id]', () => {
       // Arrange
       mockInstructorFindUnique.mockResolvedValue(null);
 
-      const mockRequest = new Request('http://localhost:3000/api/instructors/1');
+      const mockRequest = new NextRequest('http://localhost:3000/api/instructors/1');
       const context = { params: Promise.resolve({ id: '1' }) };
 
       // Act
@@ -515,7 +504,7 @@ describe('GET /api/instructors/[id]', () => {
       // Arrange
       mockInstructorFindUnique.mockResolvedValue(null);
 
-      const mockRequest = new Request('http://localhost:3000/api/instructors/42');
+      const mockRequest = new NextRequest('http://localhost:3000/api/instructors/42');
       const context = { params: Promise.resolve({ id: '42' }) };
 
       // Act
@@ -561,7 +550,7 @@ describe('GET /api/instructors/[id]', () => {
 
       mockInstructorFindUnique.mockResolvedValue(mockInstructor);
 
-      const mockRequest = new Request('http://localhost:3000/api/instructors/1');
+      const mockRequest = new NextRequest('http://localhost:3000/api/instructors/1');
       const context = { params: Promise.resolve({ id: '1' }) };
 
       // Act
@@ -598,7 +587,7 @@ describe('GET /api/instructors/[id]', () => {
       // Arrange
       mockInstructorFindUnique.mockResolvedValue(null);
 
-      const mockRequest = new Request('http://localhost:3000/api/instructors/999');
+      const mockRequest = new NextRequest('http://localhost:3000/api/instructors/999');
       const context = { params: Promise.resolve({ id: '999' }) };
 
       // Act
@@ -623,6 +612,19 @@ describe('GET /api/instructors/[id]', () => {
 describe('PUT /api/instructors/[id]', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // 認証成功をデフォルトでモック
+    mockAuthenticateFromRequest.mockResolvedValue({
+      success: true,
+      user: {
+        id: '1',
+        lineUserId: 'test-user',
+        displayName: 'Test User',
+        role: 'ADMIN',
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
     // NextResponse.jsonのデフォルトモック実装
     mockNextResponse.json.mockImplementation((data, init) => {
       return {
@@ -724,7 +726,7 @@ describe('PUT /api/instructors/[id]', () => {
         } as never);
       });
 
-      const mockRequest = new Request('http://localhost:3000/api/instructors/1', {
+      const mockRequest = new NextRequest('http://localhost:3000/api/instructors/1', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(requestBody),
@@ -816,7 +818,7 @@ describe('PUT /api/instructors/[id]', () => {
         } as never);
       });
 
-      const mockRequest = new Request('http://localhost:3000/api/instructors/2', {
+      const mockRequest = new NextRequest('http://localhost:3000/api/instructors/2', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(requestBody),
@@ -858,7 +860,7 @@ describe('PUT /api/instructors/[id]', () => {
 
       mockInstructorFindUnique.mockResolvedValue(null);
 
-      const mockRequest = new Request('http://localhost:3000/api/instructors/999', {
+      const mockRequest = new NextRequest('http://localhost:3000/api/instructors/999', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(requestBody),
@@ -888,7 +890,7 @@ describe('PUT /api/instructors/[id]', () => {
         // firstName が不足
       };
 
-      const mockRequest = new Request('http://localhost:3000/api/instructors/1', {
+      const mockRequest = new NextRequest('http://localhost:3000/api/instructors/1', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(requestBody),
@@ -919,7 +921,7 @@ describe('PUT /api/instructors/[id]', () => {
         status: 'INVALID_STATUS',
       };
 
-      const mockRequest = new Request('http://localhost:3000/api/instructors/1', {
+      const mockRequest = new NextRequest('http://localhost:3000/api/instructors/1', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(requestBody),
@@ -964,7 +966,7 @@ describe('PUT /api/instructors/[id]', () => {
       mockInstructorFindUnique.mockResolvedValue(existingInstructor as never);
       mockCertificationFindMany.mockResolvedValue(existingCertifications as never);
 
-      const mockRequest = new Request('http://localhost:3000/api/instructors/1', {
+      const mockRequest = new NextRequest('http://localhost:3000/api/instructors/1', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(requestBody),
@@ -994,7 +996,7 @@ describe('PUT /api/instructors/[id]', () => {
         firstName: '花子',
       };
 
-      const mockRequest = new Request('http://localhost:3000/api/instructors/invalid', {
+      const mockRequest = new NextRequest('http://localhost:3000/api/instructors/invalid', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(requestBody),
@@ -1028,7 +1030,7 @@ describe('PUT /api/instructors/[id]', () => {
       mockInstructorFindUnique.mockRejectedValue(mockError);
 
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
-      const mockRequest = new Request('http://localhost:3000/api/instructors/1', {
+      const mockRequest = new NextRequest('http://localhost:3000/api/instructors/1', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(requestBody),
@@ -1105,7 +1107,7 @@ describe('PUT /api/instructors/[id]', () => {
         } as never);
       });
 
-      const mockRequest = new Request('http://localhost:3000/api/instructors/1', {
+      const mockRequest = new NextRequest('http://localhost:3000/api/instructors/1', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(requestBody),

--- a/app/api/instructors/[id]/route.test.ts
+++ b/app/api/instructors/[id]/route.test.ts
@@ -46,11 +46,25 @@ jest.mock('@/lib/db', () => ({
   },
 }));
 
-// NextResponseをモック化
+// NextResponseとNextRequestをモック化
 jest.mock('next/server', () => ({
   NextResponse: {
     json: jest.fn(),
   },
+  NextRequest: jest.fn((url, init) => ({
+    url,
+    ...init,
+    headers: new Headers(init?.headers),
+    cookies: {
+      get: jest.fn().mockReturnValue({ value: 'test-token' }),
+    },
+    json: init?.body
+      ? () => Promise.resolve(JSON.parse(init.body as string))
+      : () => Promise.resolve({}),
+    nextUrl: {
+      searchParams: new URL(url as string).searchParams,
+    },
+  })),
 }));
 
 // 認証ミドルウェアをモック化

--- a/app/api/instructors/[id]/route.ts
+++ b/app/api/instructors/[id]/route.ts
@@ -1,7 +1,8 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
+import { authenticateFromRequest } from '@/lib/auth/middleware';
 
-export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const resolvedParams = await params;
     const id = resolvedParams.id;
@@ -94,7 +95,19 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
   }
 }
 
-export async function PUT(request: Request, { params }: { params: Promise<{ id: string }> }) {
+export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const authResult = await authenticateFromRequest(request);
+  if (!authResult.success) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Authentication required',
+        data: null,
+        message: null,
+      },
+      { status: 401 }
+    );
+  }
   try {
     const resolvedParams = await params;
     const id = resolvedParams.id;

--- a/app/api/instructors/route.test.ts
+++ b/app/api/instructors/route.test.ts
@@ -46,11 +46,25 @@ jest.mock('@/lib/db', () => ({
   },
 }));
 
-// NextResponseをモック化
+// NextResponseとNextRequestをモック化
 jest.mock('next/server', () => ({
   NextResponse: {
     json: jest.fn(),
   },
+  NextRequest: jest.fn((url, init) => ({
+    url,
+    ...init,
+    headers: new Headers(init?.headers),
+    cookies: {
+      get: jest.fn().mockReturnValue({ value: 'test-token' }),
+    },
+    json: init?.body
+      ? () => Promise.resolve(JSON.parse(init.body as string))
+      : () => Promise.resolve({}),
+    nextUrl: {
+      searchParams: new URL(url as string).searchParams,
+    },
+  })),
 }));
 
 // 認証ミドルウェアをモック化
@@ -82,6 +96,19 @@ const mockAuthenticateFromRequest = authenticateFromRequest as jest.MockedFuncti
 describe('GET /api/instructors', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // 認証成功をデフォルトでモック
+    mockAuthenticateFromRequest.mockResolvedValue({
+      success: true,
+      user: {
+        id: '1',
+        lineUserId: 'test-user',
+        displayName: 'Test User',
+        role: 'ADMIN',
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
     // NextResponse.jsonのデフォルトモック実装
     mockNextResponse.json.mockImplementation((data, init) => {
       return {

--- a/app/api/instructors/route.ts
+++ b/app/api/instructors/route.ts
@@ -1,4 +1,5 @@
 // NextResponse import removed as it's only used in return type
+import { NextRequest } from 'next/server';
 import { prisma } from '@/lib/db';
 import { InstructorStatus } from '@/shared/types/common';
 import {
@@ -9,8 +10,17 @@ import {
 } from '@/lib/api/response';
 import { isOneOf, validate, commonSchemas } from '@/lib/api/validation';
 import { ApiErrorType, HttpStatus, ApiSuccessResponse, ApiErrorResponse } from '@/lib/api/types';
+import { authenticateFromRequest } from '@/lib/auth/middleware';
 
-export async function GET(request: Request) {
+export async function GET(request: NextRequest) {
+  // 個人情報保護のため認証必須
+  const authResult = await authenticateFromRequest(request);
+  if (!authResult.success) {
+    return createErrorResponse('Authentication required', {
+      type: ApiErrorType.UNAUTHORIZED,
+      status: HttpStatus.UNAUTHORIZED,
+    });
+  }
   return withApiErrorHandling<ApiSuccessResponse<unknown[]> | ApiErrorResponse>(async () => {
     const { searchParams } = new URL(request.url);
     const statusParam = searchParams.get('status');
@@ -102,7 +112,14 @@ export async function GET(request: Request) {
   }, 'GET /api/instructors');
 }
 
-export async function POST(request: Request) {
+export async function POST(request: NextRequest) {
+  const authResult = await authenticateFromRequest(request);
+  if (!authResult.success) {
+    return createErrorResponse('Authentication required', {
+      type: ApiErrorType.UNAUTHORIZED,
+      status: HttpStatus.UNAUTHORIZED,
+    });
+  }
   return withApiErrorHandling<ApiSuccessResponse<unknown> | ApiErrorResponse>(async () => {
     const body = await request.json();
 

--- a/app/api/shift-types/[id]/route.test.ts
+++ b/app/api/shift-types/[id]/route.test.ts
@@ -21,11 +21,25 @@ jest.mock('@/lib/db', () => ({
   },
 }));
 
-// NextResponseをモック化
+// NextResponseとNextRequestをモック化
 jest.mock('next/server', () => ({
   NextResponse: {
     json: jest.fn(),
   },
+  NextRequest: jest.fn((url, init) => ({
+    url,
+    ...init,
+    headers: new Headers(init?.headers),
+    cookies: {
+      get: jest.fn().mockReturnValue({ value: 'test-token' }),
+    },
+    json: init?.body
+      ? () => Promise.resolve(JSON.parse(init.body as string))
+      : () => Promise.resolve({}),
+    nextUrl: {
+      searchParams: new URL(url as string).searchParams,
+    },
+  })),
 }));
 
 // 認証ミドルウェアをモック化

--- a/app/api/shift-types/[id]/route.ts
+++ b/app/api/shift-types/[id]/route.ts
@@ -1,11 +1,12 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
+import { authenticateFromRequest } from '@/lib/auth/middleware';
 
 interface Params {
   params: Promise<{ id: string }>;
 }
 
-export async function GET(request: Request, context: Params) {
+export async function GET(request: NextRequest, context: Params) {
   try {
     const { id } = await context.params;
     const shiftTypeId = parseInt(id);
@@ -55,7 +56,19 @@ export async function GET(request: Request, context: Params) {
   }
 }
 
-export async function PUT(request: Request, context: Params) {
+export async function PUT(request: NextRequest, context: Params) {
+  const authResult = await authenticateFromRequest(request);
+  if (!authResult.success) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Authentication required',
+        data: null,
+        message: null,
+      },
+      { status: 401 }
+    );
+  }
   try {
     const { id } = await context.params;
     const shiftTypeId = parseInt(id);

--- a/app/api/shift-types/route.test.ts
+++ b/app/api/shift-types/route.test.ts
@@ -21,11 +21,25 @@ jest.mock('@/lib/db', () => ({
   },
 }));
 
-// NextResponseをモック化
+// NextResponseとNextRequestをモック化
 jest.mock('next/server', () => ({
   NextResponse: {
     json: jest.fn(),
   },
+  NextRequest: jest.fn((url, init) => ({
+    url,
+    ...init,
+    headers: new Headers(init?.headers),
+    cookies: {
+      get: jest.fn().mockReturnValue({ value: 'test-token' }),
+    },
+    json: init?.body
+      ? () => Promise.resolve(JSON.parse(init.body as string))
+      : () => Promise.resolve({}),
+    nextUrl: {
+      searchParams: new URL(url as string).searchParams,
+    },
+  })),
 }));
 
 // 認証ミドルウェアをモック化

--- a/app/api/shift-types/route.test.ts
+++ b/app/api/shift-types/route.test.ts
@@ -52,7 +52,7 @@ describe('GET /api/shift-types', () => {
     mockAuthenticateFromRequest.mockResolvedValue({
       success: true,
       user: {
-        id: 1,
+        id: '1',
         lineUserId: 'test-line-user',
         displayName: 'Test User',
         profileImageUrl: null,
@@ -109,7 +109,7 @@ describe('GET /api/shift-types', () => {
       mockShiftTypeFindMany.mockResolvedValue(mockShiftTypes);
 
       // Act
-      await GET();
+      await GET(new NextRequest('http://localhost'));
 
       // Assert
       expect(mockShiftTypeFindMany).toHaveBeenCalledWith({
@@ -133,7 +133,7 @@ describe('GET /api/shift-types', () => {
       mockShiftTypeFindMany.mockResolvedValue(mockShiftTypes);
 
       // Act
-      await GET();
+      await GET(new NextRequest('http://localhost'));
 
       // Assert
       expect(mockShiftTypeFindMany).toHaveBeenCalledWith({
@@ -166,7 +166,7 @@ describe('GET /api/shift-types', () => {
       mockShiftTypeFindMany.mockResolvedValue(mockShiftTypes);
 
       // Act
-      await GET();
+      await GET(new NextRequest('http://localhost'));
 
       // Assert
       expect(mockNextResponse.json).toHaveBeenCalledWith({
@@ -189,7 +189,7 @@ describe('GET /api/shift-types', () => {
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
 
       // Act
-      await GET();
+      await GET(new NextRequest('http://localhost'));
 
       // Assert
       expect(mockShiftTypeFindMany).toHaveBeenCalledWith({
@@ -223,7 +223,7 @@ describe('GET /api/shift-types', () => {
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
 
       // Act
-      await GET();
+      await GET(new NextRequest('http://localhost'));
 
       // Assert
       expect(consoleSpy).toHaveBeenCalledWith('ShiftTypes API error:', mockError);
@@ -252,7 +252,7 @@ describe('GET /api/shift-types', () => {
       mockShiftTypeFindMany.mockResolvedValue(mockShiftTypes as ShiftType[]);
 
       // Act
-      await GET();
+      await GET(new NextRequest('http://localhost'));
 
       // Assert
       expect(mockShiftTypeFindMany).toHaveBeenCalledWith({
@@ -267,7 +267,7 @@ describe('GET /api/shift-types', () => {
       mockShiftTypeFindMany.mockResolvedValue([]);
 
       // Act
-      await GET();
+      await GET(new NextRequest('http://localhost'));
 
       // Assert
       expect(mockShiftTypeFindMany).toHaveBeenCalledTimes(1);
@@ -283,6 +283,20 @@ describe('POST /api/shift-types', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // 認証成功をデフォルトでモック
+    mockAuthenticateFromRequest.mockResolvedValue({
+      success: true,
+      user: {
+        id: '1',
+        lineUserId: 'test-line-user',
+        displayName: 'Test User',
+        profileImageUrl: null,
+        role: 'ADMIN',
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
     // NextResponse.jsonのデフォルトモック実装
     mockNextResponse.json.mockImplementation((data, init) => {
       return {

--- a/app/api/shift-types/route.ts
+++ b/app/api/shift-types/route.ts
@@ -43,7 +43,20 @@ export async function GET(request: NextRequest) {
   }
 }
 
-export async function POST(request: Request) {
+export async function POST(request: NextRequest) {
+  const authResult = await authenticateFromRequest(request);
+  if (!authResult.success) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Authentication required',
+        data: null,
+        message: null,
+      },
+      { status: 401 }
+    );
+  }
+
   try {
     const body = await request.json();
     const { name, isActive = true } = body;

--- a/app/api/shift-types/route.ts
+++ b/app/api/shift-types/route.ts
@@ -1,7 +1,20 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
+import { authenticateFromRequest } from '@/lib/auth/middleware';
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const authResult = await authenticateFromRequest(request);
+  if (!authResult.success) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Authentication required',
+        data: null,
+        message: null,
+      },
+      { status: 401 }
+    );
+  }
   try {
     const shiftTypes = await prisma.shiftType.findMany({
       orderBy: {

--- a/app/api/shifts/[id]/route.test.ts
+++ b/app/api/shifts/[id]/route.test.ts
@@ -1,6 +1,7 @@
 import { GET, PUT, DELETE } from './route';
 import { prisma } from '@/lib/db';
 import { NextRequest, NextResponse } from 'next/server';
+import { authenticateFromRequest } from '@/lib/auth/middleware';
 
 // Mock types (同じ型定義を再利用)
 type Department = {
@@ -70,13 +71,31 @@ jest.mock('@/lib/db', () => ({
   },
 }));
 
-// NextResponseをモック化
+// NextResponseとNextRequestをモック化
 jest.mock('next/server', () => ({
   NextResponse: jest.fn().mockImplementation((body, init) => ({
     status: init?.status || 200,
     json: async () => body,
     headers: new Headers(),
   })),
+  NextRequest: jest.fn((url, init) => ({
+    url,
+    ...init,
+    headers: new Headers(init?.headers),
+    cookies: {
+      get: jest.fn().mockReturnValue({ value: 'test-token' }),
+    },
+    json: init?.body
+      ? () => Promise.resolve(JSON.parse(init.body as string))
+      : () => Promise.resolve({}),
+    nextUrl: {
+      searchParams: new URL(url as string).searchParams,
+    },
+  })),
+}));
+
+jest.mock('@/lib/auth/middleware', () => ({
+  authenticateFromRequest: jest.fn(),
 }));
 
 // NextResponseをjsonとコンストラクタの両方でモック化
@@ -89,6 +108,9 @@ const mockShiftFindUnique = mockPrisma.shift.findUnique as jest.MockedFunction<
   typeof prisma.shift.findUnique
 >;
 const mockTransaction = mockPrisma.$transaction as jest.MockedFunction<typeof prisma.$transaction>;
+const mockAuthenticateFromRequest = authenticateFromRequest as jest.MockedFunction<
+  typeof authenticateFromRequest
+>;
 
 // テスト用のモックデータ
 const mockDepartment: Department = {
@@ -145,6 +167,18 @@ const mockShift: Shift = {
 describe('Shifts [id] API', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockAuthenticateFromRequest.mockResolvedValue({
+      success: true,
+      user: {
+        id: '1',
+        lineUserId: 'test-user',
+        displayName: 'Test User',
+        role: 'ADMIN',
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
     // NextResponse.jsonのデフォルトモック実装
     mockNextResponseJson.mockImplementation(
       (
@@ -198,7 +232,7 @@ describe('Shifts [id] API', () => {
   });
 
   describe('GET /api/shifts/[id]', () => {
-    const createMockGetRequest = () => ({}) as NextRequest;
+    const createMockGetRequest = () => new NextRequest('http://localhost/api/shifts/1');
     const createMockContext = (id: string) => ({
       params: Promise.resolve({ id }),
     });
@@ -324,9 +358,10 @@ describe('Shifts [id] API', () => {
 
   describe('PUT /api/shifts/[id]', () => {
     const createMockPutRequest = (body: Record<string, unknown>) =>
-      ({
-        json: async () => body,
-      }) as NextRequest;
+      new NextRequest('http://localhost/api/shifts/1', {
+        method: 'PUT',
+        body: JSON.stringify(body),
+      });
     const createMockContext = (id: string) => ({
       params: Promise.resolve({ id }),
     });
@@ -443,7 +478,7 @@ describe('Shifts [id] API', () => {
   });
 
   describe('DELETE /api/shifts/[id]', () => {
-    const createMockDeleteRequest = () => ({}) as NextRequest;
+    const createMockDeleteRequest = () => new NextRequest('http://localhost/api/shifts/1', { method: 'DELETE' });
     const createMockContext = (id: string) => ({
       params: Promise.resolve({ id }),
     });

--- a/app/api/shifts/[id]/route.test.ts
+++ b/app/api/shifts/[id]/route.test.ts
@@ -478,7 +478,8 @@ describe('Shifts [id] API', () => {
   });
 
   describe('DELETE /api/shifts/[id]', () => {
-    const createMockDeleteRequest = () => new NextRequest('http://localhost/api/shifts/1', { method: 'DELETE' });
+    const createMockDeleteRequest = () =>
+      new NextRequest('http://localhost/api/shifts/1', { method: 'DELETE' });
     const createMockContext = (id: string) => ({
       params: Promise.resolve({ id }),
     });

--- a/app/api/shifts/[id]/route.ts
+++ b/app/api/shifts/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { NextRequest } from 'next/server';
 import { prisma } from '@/lib/db';
+import { authenticateFromRequest } from '@/lib/auth/middleware';
 
 interface Params {
   id: string;
@@ -95,6 +96,18 @@ export async function GET(request: NextRequest, context: { params: Promise<Param
 }
 
 export async function PUT(request: NextRequest, context: { params: Promise<Params> }) {
+  const authResult = await authenticateFromRequest(request);
+  if (!authResult.success) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Authentication required',
+        data: null,
+        message: null,
+      },
+      { status: 401 }
+    );
+  }
   try {
     const params = await context.params;
     const id = parseInt(params.id);
@@ -231,6 +244,18 @@ export async function PUT(request: NextRequest, context: { params: Promise<Param
 }
 
 export async function DELETE(request: NextRequest, context: { params: Promise<Params> }) {
+  const authResult = await authenticateFromRequest(request);
+  if (!authResult.success) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Authentication required',
+        data: null,
+        message: null,
+      },
+      { status: 401 }
+    );
+  }
   try {
     const params = await context.params;
     const id = parseInt(params.id);

--- a/app/api/shifts/prepare/route.ts
+++ b/app/api/shifts/prepare/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import { NextRequest } from 'next/server';
+import { authenticateFromRequest } from '@/lib/auth/middleware';
 
 // 既存シフトデータの型定義（レスポンス用）
 interface ExistingShiftData {
@@ -105,6 +106,17 @@ function formatExistingShift(shift: ShiftWithRelations): ExistingShiftData {
 }
 
 export async function GET(request: NextRequest) {
+  const authResult = await authenticateFromRequest(request);
+  if (!authResult.success) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Authentication required',
+      },
+      { status: 401 }
+    );
+  }
+
   try {
     const { searchParams } = request.nextUrl;
     const date = searchParams.get('date');

--- a/app/api/shifts/route.ts
+++ b/app/api/shifts/route.ts
@@ -1,8 +1,21 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import { NextRequest } from 'next/server';
+import { authenticateFromRequest } from '@/lib/auth/middleware';
 
 export async function GET(request: NextRequest) {
+  const authResult = await authenticateFromRequest(request);
+  if (!authResult.success) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Authentication required',
+        data: null,
+        message: null,
+      },
+      { status: 401 }
+    );
+  }
   try {
     const searchParams = request.nextUrl.searchParams;
     const departmentId = searchParams.get('departmentId');
@@ -100,6 +113,19 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
+  const authResult = await authenticateFromRequest(request);
+  if (!authResult.success) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Authentication required',
+        data: null,
+        message: null,
+      },
+      { status: 401 }
+    );
+  }
+
   try {
     const body = await request.json();
     const {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -582,6 +582,199 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
+  /api/auth/invitations:
+    post:
+      summary: 招待トークン作成
+      description: 管理者またはマネージャーが新しい招待トークンを作成します。
+      tags:
+        - 招待管理
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InvitationCreateInput'
+      responses:
+        '201':
+          description: 招待トークンの作成に成功
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/InvitationUrl'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
+    get:
+      summary: 招待トークン一覧取得
+      description: 作成済みの招待トークン一覧を取得します。管理者は `showAll=true` で全件取得できます。
+      tags:
+        - 招待管理
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: includeInactive
+          in: query
+          description: 無効化済みトークンを含める場合は `true`
+          schema:
+            type: boolean
+        - name: showAll
+          in: query
+          description: 管理者のみ指定可能。全ユーザーのトークンを表示します。
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: 招待トークン一覧
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiListResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/InvitationToken'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
+  /api/auth/invitations/{token}:
+    parameters:
+      - name: token
+        in: path
+        required: true
+        description: 招待トークン文字列
+        schema:
+          type: string
+
+    delete:
+      summary: 招待トークン無効化
+      description: 管理者または作成者が招待トークンを無効化します。
+      tags:
+        - 招待管理
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: 招待トークンの無効化に成功
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/InvitationDeactivation'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: すでに無効化済み
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+              example:
+                success: false
+                error: 'Invitation token is already inactive'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
+  /api/auth/invitations/active:
+    get:
+      summary: 最新の有効な招待トークン取得
+      description: 現在利用可能な最新の招待トークン情報を返します。
+      tags:
+        - 招待管理
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: 有効な招待トークン情報
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/ActiveInvitation'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
+  /api/auth/invitations/{token}/verify:
+    parameters:
+      - name: token
+        in: path
+        required: true
+        description: 招待トークン文字列
+        schema:
+          type: string
+
+    get:
+      summary: 招待トークン検証
+      description: 認証なしで招待トークンの有効性を検証します。
+      tags:
+        - 招待管理
+      responses:
+        '200':
+          description: 招待トークンが有効
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/InvitationValidation'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '410':
+          description: トークンは存在したが現在は利用不可
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+              example:
+                success: false
+                error: 'Expired invitation token'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
     put:
       summary: シフト更新
       description: 指定されたシフトを更新
@@ -647,8 +840,6 @@ components:
             $ref: '#/components/schemas/ApiErrorResponse'
           example:
             success: false
-            data: null
-            message: null
             error: 'Resource not found'
 
     ValidationError:
@@ -659,8 +850,6 @@ components:
             $ref: '#/components/schemas/ApiErrorResponse'
           example:
             success: false
-            data: null
-            message: null
             error: 'Validation failed'
 
     ServerError:
@@ -671,9 +860,33 @@ components:
             $ref: '#/components/schemas/ApiErrorResponse'
           example:
             success: false
-            data: null
-            message: null
             error: 'Internal server error'
+
+    Unauthorized:
+      description: 認証が必要です
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiErrorResponse'
+          example:
+            success: false
+            error: 'Authentication token required'
+
+    Forbidden:
+      description: 権限が不足しています
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiErrorResponse'
+          example:
+            success: false
+            error: 'Insufficient permissions. Admin or Manager role required.'
+
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
 
   schemas:
     # 軽量版スキーマ
@@ -722,6 +935,8 @@ components:
     # 基本レスポンス
     ApiResponse:
       type: object
+      required:
+        - success
       properties:
         success:
           type: boolean
@@ -729,10 +944,6 @@ components:
         data:
           type: object
           nullable: true
-        message:
-          type: string
-          nullable: true
-          example: 'Operation completed successfully'
         error:
           type: string
           nullable: true
@@ -740,6 +951,8 @@ components:
 
     ApiListResponse:
       type: object
+      required:
+        - success
       properties:
         success:
           type: boolean
@@ -751,9 +964,6 @@ components:
         count:
           type: integer
           example: 10
-        message:
-          type: string
-          nullable: true
         error:
           type: string
           nullable: true
@@ -761,20 +971,16 @@ components:
 
     ApiErrorResponse:
       type: object
+      required:
+        - success
+        - error
       properties:
         success:
           type: boolean
           example: false
-        data:
-          type: object
-          nullable: true
-          example: null
-        message:
-          type: string
-          nullable: true
         error:
           type: string
-          example: 'Error message'
+          example: 'Invalid invitation token'
 
     # 部門関連
     Department:
@@ -1225,6 +1431,123 @@ components:
           description: '事前選択されるインストラクターIDの配列'
           example: [3, 5]
 
+    InvitationCreateInput:
+      type: object
+      required:
+        - expiresAt
+      properties:
+        description:
+          type: string
+          nullable: true
+          example: '新人スタッフ用招待'
+        expiresAt:
+          type: string
+          format: date-time
+          example: '2025-01-15T12:00:00Z'
+
+    InvitationUrl:
+      type: object
+      properties:
+        token:
+          type: string
+          example: 'inv_abcd1234'
+        invitationUrl:
+          type: string
+          example: 'https://app.example.com/login?invite=inv_abcd1234'
+        expiresAt:
+          type: string
+          format: date-time
+        maxUses:
+          type: integer
+          nullable: true
+          example: 5
+        createdBy:
+          type: string
+          example: 'user_admin_01'
+
+    InvitationToken:
+      type: object
+      properties:
+        token:
+          type: string
+        description:
+          type: string
+        expiresAt:
+          type: string
+          format: date-time
+        isActive:
+          type: boolean
+        maxUses:
+          type: integer
+          nullable: true
+        usedCount:
+          type: integer
+        createdAt:
+          type: string
+          format: date-time
+        createdBy:
+          type: string
+        creatorName:
+          type: string
+        creatorRole:
+          type: string
+          enum: [ADMIN, MANAGER, MEMBER]
+        isExpired:
+          type: boolean
+        remainingUses:
+          type: integer
+          nullable: true
+
+    InvitationDeactivation:
+      type: object
+      properties:
+        message:
+          type: string
+          example: 'Invitation token deactivated successfully'
+        token:
+          type: string
+        deactivatedAt:
+          type: string
+          format: date-time
+        deactivatedBy:
+          type: string
+
+    ActiveInvitation:
+      type: object
+      properties:
+        token:
+          type: string
+        description:
+          type: string
+          nullable: true
+        expiresAt:
+          type: string
+          format: date-time
+        isActive:
+          type: boolean
+        maxUses:
+          type: integer
+          nullable: true
+        usageCount:
+          type: integer
+        remainingUses:
+          type: integer
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        createdBy:
+          type: string
+
+    InvitationValidation:
+      type: object
+      required:
+        - isValid
+      properties:
+        isValid:
+          type: boolean
+          example: true
+
 tags:
   - name: システム
     description: システム関連のエンドポイント
@@ -1238,3 +1561,5 @@ tags:
     description: シフト種類マスタの管理
   - name: シフト管理
     description: シフト枠の管理
+  - name: 招待管理
+    description: 招待トークンおよび認証周りの管理

--- a/jest.config.js
+++ b/jest.config.js
@@ -84,7 +84,7 @@ const customJestConfig = {
   ],
   // Transform ignore patterns for ES modules
   transformIgnorePatterns: [
-    'node_modules/(?!(.*\\.mjs$|@tanstack|lucide-react|date-fns|japanese-holidays))',
+    'node_modules/(?!(.*\\.mjs$|@tanstack|lucide-react|date-fns|japanese-holidays|is-ip|ip-regex))',
   ],
   // Global setup for tests
   globalSetup: undefined,

--- a/lib/api/__tests__/rate-limiting.test.ts
+++ b/lib/api/__tests__/rate-limiting.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Rate Limiting Test
+ */
+
+import { checkRateLimit, clearRateLimitStore, getRateLimitStatus } from '../rate-limiting';
+
+describe('Rate Limiting', () => {
+  beforeEach(() => {
+    clearRateLimitStore();
+  });
+
+  it('should allow requests within limit', () => {
+    const ip = '127.0.0.1';
+    const pathname = '/api/health';
+
+    // 最初のリクエストは許可
+    const result1 = checkRateLimit(ip, pathname);
+    expect(result1.allowed).toBe(true);
+    expect(result1.remaining).toBe(99); // 100 - 1
+    expect(result1.limit).toBe(100);
+
+    // 2回目のリクエストも許可
+    const result2 = checkRateLimit(ip, pathname);
+    expect(result2.allowed).toBe(true);
+    expect(result2.remaining).toBe(98); // 100 - 2
+  });
+
+  it('should block requests when limit exceeded', () => {
+    const ip = '127.0.0.1';
+    const pathname = '/api/health';
+
+    // 制限まで送信
+    for (let i = 0; i < 100; i++) {
+      const result = checkRateLimit(ip, pathname);
+      expect(result.allowed).toBe(true);
+    }
+
+    // 101回目は拒否
+    const result = checkRateLimit(ip, pathname);
+    expect(result.allowed).toBe(false);
+    expect(result.remaining).toBe(0);
+  });
+
+  it('should apply different limits for auth APIs', () => {
+    const ip = '127.0.0.1';
+    const authPath = '/api/auth/login';
+
+    // 認証APIは15分に10回の制限
+    for (let i = 0; i < 10; i++) {
+      const result = checkRateLimit(ip, authPath);
+      expect(result.allowed).toBe(true);
+    }
+
+    // 11回目は拒否
+    const result = checkRateLimit(ip, authPath);
+    expect(result.allowed).toBe(false);
+    expect(result.limit).toBe(10);
+  });
+
+  it('should track different IPs separately', () => {
+    const pathname = '/api/health';
+
+    // IP1は制限に達する
+    for (let i = 0; i < 100; i++) {
+      checkRateLimit('192.168.1.1', pathname);
+    }
+    const result1 = checkRateLimit('192.168.1.1', pathname);
+    expect(result1.allowed).toBe(false);
+
+    // IP2は新しいカウンター
+    const result2 = checkRateLimit('192.168.1.2', pathname);
+    expect(result2.allowed).toBe(true);
+    expect(result2.remaining).toBe(99);
+  });
+
+  it('should provide rate limit status', () => {
+    checkRateLimit('127.0.0.1', '/api/health');
+    checkRateLimit('127.0.0.1', '/api/auth/login');
+
+    const status = getRateLimitStatus();
+    expect(status.totalEntries).toBe(2);
+    expect(status.generalEntries).toBe(1);
+    expect(status.authEntries).toBe(1);
+  });
+});

--- a/lib/api/__tests__/rate-limiting.test.ts
+++ b/lib/api/__tests__/rate-limiting.test.ts
@@ -9,77 +9,113 @@ describe('Rate Limiting', () => {
     clearRateLimitStore();
   });
 
-  it('should allow requests within limit', () => {
+  it('should allow requests within general API limit', () => {
     const ip = '127.0.0.1';
     const pathname = '/api/health';
 
-    // 最初のリクエストは許可
     const result1 = checkRateLimit(ip, pathname);
     expect(result1.allowed).toBe(true);
-    expect(result1.remaining).toBe(99); // 100 - 1
+    expect(result1.remaining).toBe(99);
     expect(result1.limit).toBe(100);
+    expect(result1.ruleId).toBe('api-general');
 
-    // 2回目のリクエストも許可
     const result2 = checkRateLimit(ip, pathname);
     expect(result2.allowed).toBe(true);
-    expect(result2.remaining).toBe(98); // 100 - 2
+    expect(result2.remaining).toBe(98);
+    expect(result2.ruleId).toBe('api-general');
   });
 
-  it('should block requests when limit exceeded', () => {
+  it('should block requests when general limit exceeded', () => {
     const ip = '127.0.0.1';
     const pathname = '/api/health';
 
-    // 制限まで送信
     for (let i = 0; i < 100; i++) {
       const result = checkRateLimit(ip, pathname);
       expect(result.allowed).toBe(true);
+      expect(result.ruleId).toBe('api-general');
     }
 
-    // 101回目は拒否
-    const result = checkRateLimit(ip, pathname);
-    expect(result.allowed).toBe(false);
-    expect(result.remaining).toBe(0);
+    const exceeded = checkRateLimit(ip, pathname);
+    expect(exceeded.allowed).toBe(false);
+    expect(exceeded.remaining).toBe(0);
+    expect(exceeded.ruleId).toBe('api-general');
   });
 
   it('should apply different limits for auth APIs', () => {
     const ip = '127.0.0.1';
     const authPath = '/api/auth/login';
 
-    // 認証APIは15分に10回の制限
     for (let i = 0; i < 10; i++) {
       const result = checkRateLimit(ip, authPath);
       expect(result.allowed).toBe(true);
+      expect(result.ruleId).toBe('auth-general');
     }
 
-    // 11回目は拒否
-    const result = checkRateLimit(ip, authPath);
-    expect(result.allowed).toBe(false);
-    expect(result.limit).toBe(10);
+    const exceeded = checkRateLimit(ip, authPath);
+    expect(exceeded.allowed).toBe(false);
+    expect(exceeded.limit).toBe(10);
+    expect(exceeded.ruleId).toBe('auth-general');
+  });
+
+  it('should enforce stricter limit for invitation verification', () => {
+    const ip = '127.0.0.1';
+    const verifyPath = '/api/auth/invitations/demo-token/verify';
+
+    for (let i = 0; i < 5; i++) {
+      const result = checkRateLimit(ip, verifyPath);
+      expect(result.allowed).toBe(true);
+      expect(result.limit).toBe(5);
+      expect(result.ruleId).toBe('auth-invitation-verify');
+    }
+
+    const exceeded = checkRateLimit(ip, verifyPath);
+    expect(exceeded.allowed).toBe(false);
+    expect(exceeded.remaining).toBe(0);
+    expect(exceeded.ruleId).toBe('auth-invitation-verify');
+  });
+
+  it('should enforce stricter limit for LINE login endpoint', () => {
+    const ip = '127.0.0.1';
+    const loginPath = '/api/auth/line/login';
+
+    for (let i = 0; i < 5; i++) {
+      const result = checkRateLimit(ip, loginPath);
+      expect(result.allowed).toBe(true);
+      expect(result.limit).toBe(5);
+      expect(result.ruleId).toBe('auth-line-login');
+    }
+
+    const exceeded = checkRateLimit(ip, loginPath);
+    expect(exceeded.allowed).toBe(false);
+    expect(exceeded.remaining).toBe(0);
+    expect(exceeded.ruleId).toBe('auth-line-login');
   });
 
   it('should track different IPs separately', () => {
     const pathname = '/api/health';
 
-    // IP1は制限に達する
     for (let i = 0; i < 100; i++) {
       checkRateLimit('192.168.1.1', pathname);
     }
     const result1 = checkRateLimit('192.168.1.1', pathname);
     expect(result1.allowed).toBe(false);
+    expect(result1.ruleId).toBe('api-general');
 
-    // IP2は新しいカウンター
     const result2 = checkRateLimit('192.168.1.2', pathname);
     expect(result2.allowed).toBe(true);
     expect(result2.remaining).toBe(99);
+    expect(result2.ruleId).toBe('api-general');
   });
 
-  it('should provide rate limit status', () => {
+  it('should provide rate limit status grouped by bucket', () => {
     checkRateLimit('127.0.0.1', '/api/health');
     checkRateLimit('127.0.0.1', '/api/auth/login');
+    checkRateLimit('127.0.0.1', '/api/auth/line/login');
 
     const status = getRateLimitStatus();
-    expect(status.totalEntries).toBe(2);
-    expect(status.generalEntries).toBe(1);
-    expect(status.authEntries).toBe(1);
+    expect(status.totalEntries).toBe(3);
+    expect(status.buckets['api-general']).toBe(1);
+    expect(status.buckets['auth-general']).toBe(1);
+    expect(status.buckets['auth-line-login']).toBe(1);
   });
 });

--- a/lib/api/rate-limiting.ts
+++ b/lib/api/rate-limiting.ts
@@ -1,0 +1,147 @@
+/**
+ * Rate Limiting Implementation
+ * メモリベースのRate Limiting（開発・小規模運用向け）
+ */
+
+interface RateLimitEntry {
+  count: number;
+  resetTime: number;
+}
+
+interface RateLimitConfig {
+  windowMs: number; // 時間窓（ミリ秒）
+  maxRequests: number; // 最大リクエスト数
+}
+
+// メモリベースのストレージ
+const rateLimitStore = new Map<string, RateLimitEntry>();
+
+// 設定
+const RATE_LIMIT_CONFIGS: Record<string, RateLimitConfig> = {
+  '/api/auth/': { windowMs: 15 * 60 * 1000, maxRequests: 10 }, // 15分に10回
+  '/api/': { windowMs: 60 * 1000, maxRequests: 100 }, // 1分に100回
+};
+
+/**
+ * IPアドレスとパスから識別子を生成
+ */
+function generateIdentifier(ip: string, pathname: string): string {
+  // 認証APIは特別扱い
+  if (pathname.startsWith('/api/auth/')) {
+    return `auth:${ip}`;
+  }
+  return `general:${ip}`;
+}
+
+/**
+ * 適用するRate Limit設定を取得
+ */
+function getRateLimitConfig(pathname: string): RateLimitConfig {
+  if (pathname.startsWith('/api/auth/')) {
+    return (
+      RATE_LIMIT_CONFIGS['/api/auth/'] ??
+      RATE_LIMIT_CONFIGS['/api/'] ?? { windowMs: 15 * 60 * 1000, maxRequests: 10 }
+    );
+  }
+  return RATE_LIMIT_CONFIGS['/api/'] ?? { windowMs: 60 * 1000, maxRequests: 100 };
+}
+
+/**
+ * 期限切れエントリをクリーンアップ
+ */
+function cleanupExpiredEntries(): void {
+  const now = Date.now();
+  for (const [key, entry] of rateLimitStore.entries()) {
+    if (now > entry.resetTime) {
+      rateLimitStore.delete(key);
+    }
+  }
+}
+
+/**
+ * Rate Limitチェックを実行
+ */
+export function checkRateLimit(
+  ip: string,
+  pathname: string
+): {
+  allowed: boolean;
+  remaining: number;
+  resetTime: number;
+  limit: number;
+} {
+  // 定期的なクリーンアップ（10%の確率で実行）
+  if (Math.random() < 0.1) {
+    cleanupExpiredEntries();
+  }
+
+  const identifier = generateIdentifier(ip, pathname);
+  const config = getRateLimitConfig(pathname);
+  const now = Date.now();
+  const resetTime = now + config.windowMs;
+
+  // 既存エントリを取得または新規作成
+  let entry = rateLimitStore.get(identifier);
+
+  if (!entry || now > entry.resetTime) {
+    // 新しい時間窓の開始
+    entry = {
+      count: 1,
+      resetTime,
+    };
+    rateLimitStore.set(identifier, entry);
+
+    return {
+      allowed: true,
+      remaining: config.maxRequests - 1,
+      resetTime,
+      limit: config.maxRequests,
+    };
+  }
+
+  // 既存の時間窓内
+  entry.count++;
+
+  const allowed = entry.count <= config.maxRequests;
+  const remaining = Math.max(0, config.maxRequests - entry.count);
+
+  return {
+    allowed,
+    remaining,
+    resetTime: entry.resetTime,
+    limit: config.maxRequests,
+  };
+}
+
+/**
+ * 現在のRate Limit状況を取得（デバッグ用）
+ */
+export function getRateLimitStatus(): {
+  totalEntries: number;
+  authEntries: number;
+  generalEntries: number;
+} {
+  let authEntries = 0;
+  let generalEntries = 0;
+
+  for (const key of rateLimitStore.keys()) {
+    if (key.startsWith('auth:')) {
+      authEntries++;
+    } else {
+      generalEntries++;
+    }
+  }
+
+  return {
+    totalEntries: rateLimitStore.size,
+    authEntries,
+    generalEntries,
+  };
+}
+
+/**
+ * Rate Limitストレージをクリア（テスト用）
+ */
+export function clearRateLimitStore(): void {
+  rateLimitStore.clear();
+}

--- a/lib/auth/types.ts
+++ b/lib/auth/types.ts
@@ -33,13 +33,6 @@ export interface InvitationListItem {
 // 招待URL検証APIのレスポンス型
 export interface InvitationValidationData {
   isValid: boolean;
-  token?: string;
-  expiresAt?: string;
-  maxUses?: number | null;
-  usedCount?: number;
-  remainingUses?: number | null;
-  createdBy?: string;
-  creatorName?: string;
   error?: string;
   errorCode?: 'NOT_FOUND' | 'EXPIRED' | 'INACTIVE' | 'MAX_USES_EXCEEDED';
 }

--- a/lib/utils/__tests__/request.test.ts
+++ b/lib/utils/__tests__/request.test.ts
@@ -1,0 +1,89 @@
+import { getClientIp } from '../request';
+import type { NextRequest } from 'next/server';
+
+describe('getClientIp', () => {
+  const createRequest = (
+    options: {
+      headers?: Record<string, string>;
+      ip?: string | null;
+      cfConnectingIp?: string | null;
+    } = {}
+  ): NextRequest => {
+    const headerEntries = new Map<string, string>();
+    for (const [key, value] of Object.entries(options.headers ?? {})) {
+      headerEntries.set(key.toLowerCase(), value);
+    }
+
+    const headers = {
+      get(name: string) {
+        return headerEntries.get(name.toLowerCase()) ?? null;
+      },
+    } as unknown as Headers;
+
+    const requestStub: Partial<NextRequest> & {
+      headers: Headers;
+      ip?: string | null;
+      cf?: { connectingIP?: string | null } | null;
+    } = {
+      headers,
+      ip: options.ip ?? null,
+      cf: options.cfConnectingIp ? { connectingIP: options.cfConnectingIp } : null,
+    };
+
+    return requestStub as NextRequest;
+  };
+
+  it('prefers Cloudflare connecting IP header when available', () => {
+    const request = createRequest({
+      headers: {
+        'cf-connecting-ip': '203.0.113.10',
+        'x-forwarded-for': '198.51.100.20, 10.0.0.1',
+      },
+    });
+
+    expect(getClientIp(request)).toBe('203.0.113.10');
+  });
+
+  it('uses Cloudflare runtime connectingIP when provided', () => {
+    const request = createRequest({
+      cfConnectingIp: '198.51.100.5',
+    });
+
+    expect(getClientIp(request)).toBe('198.51.100.5');
+  });
+
+  it('falls back to NextRequest.ip when proxy headers are absent', () => {
+    const request = createRequest({
+      ip: '192.0.2.15',
+    });
+
+    expect(getClientIp(request)).toBe('192.0.2.15');
+  });
+
+  it('falls back to first X-Forwarded-For entry as a last resort', () => {
+    const request = createRequest({
+      headers: {
+        'x-forwarded-for': '198.51.100.20, 203.0.113.1',
+      },
+    });
+
+    expect(getClientIp(request)).toBe('198.51.100.20');
+  });
+
+  it('ignores spoofed or malformed IP values', () => {
+    const request = createRequest({
+      headers: {
+        'cf-connecting-ip': 'bad\nvalue',
+        'x-forwarded-for': 'malicious\\value, 203.0.113.50',
+      },
+    });
+
+    expect(getClientIp(request)).toBe('203.0.113.50');
+  });
+
+  it('returns loopback IP when no headers are present', () => {
+    const request = createRequest();
+
+    expect(getClientIp(request)).toBe('127.0.0.1');
+  });
+});

--- a/lib/utils/request.ts
+++ b/lib/utils/request.ts
@@ -1,0 +1,42 @@
+import { NextRequest } from 'next/server';
+
+/**
+ * リクエストからクライアントIPを取得
+ * X-Forwarded-For > X-Real-IP > request.ip > ローカルデフォルト
+ */
+export function getClientIp(request: NextRequest): string {
+  const forwardedFor = request.headers.get('x-forwarded-for');
+  if (forwardedFor) {
+    const ip = forwardedFor
+      .split(',')
+      .map((value) => value.trim())
+      .find((value) => value.length > 0);
+    if (ip) {
+      return ip;
+    }
+  }
+
+  const realIp = request.headers.get('x-real-ip');
+  if (realIp && realIp.trim().length > 0) {
+    return realIp.trim();
+  }
+
+  const requestWithIp = request as NextRequest & { ip?: string | null };
+  const requestIp = requestWithIp.ip;
+  if (typeof requestIp === 'string' && requestIp.trim().length > 0) {
+    return requestIp.trim();
+  }
+
+  return '127.0.0.1';
+}
+
+/**
+ * リクエストヘッダーからUser-Agentを取得
+ */
+export function getRequestUserAgent(request: NextRequest): string {
+  const userAgent = request.headers.get('user-agent');
+  if (userAgent && userAgent.trim().length > 0) {
+    return userAgent;
+  }
+  return 'unknown';
+}

--- a/lib/utils/request.ts
+++ b/lib/utils/request.ts
@@ -1,30 +1,121 @@
 import { NextRequest } from 'next/server';
 
-/**
- * リクエストからクライアントIPを取得
- * X-Forwarded-For > X-Real-IP > request.ip > ローカルデフォルト
- */
-export function getClientIp(request: NextRequest): string {
-  const forwardedFor = request.headers.get('x-forwarded-for');
-  if (forwardedFor) {
-    const ip = forwardedFor
-      .split(',')
-      .map((value) => value.trim())
-      .find((value) => value.length > 0);
-    if (ip) {
-      return ip;
+const TRUSTED_HEADER_CANDIDATES = [
+  'cf-connecting-ip',
+  'true-client-ip',
+  'cf-connecting-ipv6',
+] as const;
+
+function sanitizeIpValue(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  if (/[\s\t\n\r]/.test(trimmed)) {
+    return null;
+  }
+
+  // IPv4 + optional port (e.g. 203.0.113.1 or 203.0.113.1:8080)
+  const ipv4Match = trimmed.match(/^([0-9]{1,3}(?:\.[0-9]{1,3}){3})(?::([0-9]{1,5}))?$/);
+  if (ipv4Match) {
+    const address = ipv4Match[1];
+    if (!address) {
+      return null;
+    }
+    const port = ipv4Match[2];
+    const segments = address.split('.');
+    const isValidSegments = segments.every((segment) => {
+      const numeric = Number(segment);
+      return numeric >= 0 && numeric <= 255;
+    });
+    if (!isValidSegments) {
+      return null;
+    }
+
+    if (port && Number(port) > 65535) {
+      return null;
+    }
+
+    return address;
+  }
+
+  // IPv6 (plain) e.g. 2001:db8::1 or ::ffff:192.0.2.128
+  if (/^[0-9A-Fa-f:.]+$/.test(trimmed) && trimmed.length <= 45) {
+    return trimmed;
+  }
+
+  // IPv6 with brackets and optional port e.g. [2001:db8::1]:443
+  const ipv6BracketMatch = trimmed.match(/^\[([0-9A-Fa-f:.]+)\](?::([0-9]{1,5}))?$/);
+  if (ipv6BracketMatch) {
+    const address = ipv6BracketMatch[1];
+    if (!address) {
+      return null;
+    }
+    const port = ipv6BracketMatch[2];
+    if (port && Number(port) > 65535) {
+      return null;
+    }
+    if (address.length <= 45 && /^[0-9A-Fa-f:.]+$/.test(address)) {
+      return address;
     }
   }
 
-  const realIp = request.headers.get('x-real-ip');
-  if (realIp && realIp.trim().length > 0) {
-    return realIp.trim();
+  return null;
+}
+
+function extractIpFromHeader(
+  request: NextRequest,
+  headerName: string,
+  options?: { allowMultiple?: boolean }
+): string | null {
+  const rawValue = request.headers.get(headerName);
+  if (!rawValue) {
+    return null;
   }
 
-  const requestWithIp = request as NextRequest & { ip?: string | null };
-  const requestIp = requestWithIp.ip;
-  if (typeof requestIp === 'string' && requestIp.trim().length > 0) {
-    return requestIp.trim();
+  const values = options?.allowMultiple ? rawValue.split(',') : [rawValue];
+  for (const value of values) {
+    const sanitized = sanitizeIpValue(value);
+    if (sanitized) {
+      return sanitized;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * リクエストからクライアントIPを取得
+ * Cloudflare/Vercelなどの信頼できるヘッダーを優先し、フォールバックとして一般的なヘッダーを使用
+ */
+export function getClientIp(request: NextRequest): string {
+  const requestWithMeta = request as NextRequest & {
+    ip?: string | null;
+    cf?: { connectingIP?: string } | null;
+  };
+
+  const candidateIps: Array<string | null> = [];
+
+  // Cloudflare Workers runtime exposes request.cf.connectingIP
+  candidateIps.push(sanitizeIpValue(requestWithMeta.cf?.connectingIP));
+
+  for (const headerName of TRUSTED_HEADER_CANDIDATES) {
+    candidateIps.push(extractIpFromHeader(request, headerName));
+  }
+
+  candidateIps.push(sanitizeIpValue(requestWithMeta.ip));
+  candidateIps.push(extractIpFromHeader(request, 'x-real-ip'));
+  candidateIps.push(extractIpFromHeader(request, 'x-forwarded-for', { allowMultiple: true }));
+
+  for (const ip of candidateIps) {
+    if (ip) {
+      return ip;
+    }
   }
 
   return '127.0.0.1';

--- a/middleware.ts
+++ b/middleware.ts
@@ -119,6 +119,12 @@ export async function middleware(request: NextRequest) {
 
   // APIルートの処理
   if (pathname.startsWith('/api/')) {
+    // プリフライト要求はレートリミット対象外（CORS通過専用）
+    if (request.method === 'OPTIONS') {
+      secureLog('info', 'Middleware: Skipping rate limit for OPTIONS request', { pathname });
+      return NextResponse.next();
+    }
+
     // Rate Limitチェック
     const ip = getClientIp(request);
     const rateLimitResult = checkRateLimit(ip, pathname);

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
+        "is-ip": "^5.0.1",
         "japanese-holidays": "^1.0.10",
         "jsonwebtoken": "^9.0.2",
         "lucide-react": "^0.535.0",
@@ -16607,6 +16608,21 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/clone-regexp": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-3.0.0.tgz",
+      "integrity": "sha512-ujdnoq2Kxb8s3ItNBtnYeXdm07FcU0u8ARAT1lQ2YdMwQC+cdiXX8KoqMVuglztILivceTtp4ivqGSmEmhBUJw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-regexp": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cloudflare": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/cloudflare/-/cloudflare-4.5.0.tgz",
@@ -16760,6 +16776,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/convert-hrtime": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-5.0.0.tgz",
+      "integrity": "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/convert-source-map": {
@@ -18759,6 +18787,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/function-timeout": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-0.1.1.tgz",
+      "integrity": "sha512-0NVVC0TaP7dSTvn1yMiy6d6Q8gifzbvQafO46RtLG/kHJUBNd+pVRGOBoK44wNBvtSPUJRfdVvkFdD3p0xvyZg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/function.prototype.name": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
@@ -19354,6 +19394,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ip-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
+      "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -19602,6 +19654,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-ip": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-5.0.1.tgz",
+      "integrity": "sha512-FCsGHdlrOnZQcp0+XT5a+pYowf33itBalCl+7ovNXC/7o5BhIpG14M3OrpPPdBSIQJCm+0M5+9mO7S9VVTTCFw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-regex": "^5.0.0",
+        "super-regex": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -19685,6 +19753,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regexp": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-3.1.0.tgz",
+      "integrity": "sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-set": {
@@ -25085,6 +25165,23 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/super-regex": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/super-regex/-/super-regex-0.2.0.tgz",
+      "integrity": "sha512-WZzIx3rC1CvbMDloLsVw0lkZVKJWbrkJ0k1ghKFmcnPrW1+jWbgTkTEWVtD9lMdmI4jZEz40+naBxl1dCUhXXw==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-regexp": "^3.0.0",
+        "function-timeout": "^0.1.0",
+        "time-span": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -25338,6 +25435,21 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/time-span": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/time-span/-/time-span-5.1.0.tgz",
+      "integrity": "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==",
+      "license": "MIT",
+      "dependencies": {
+        "convert-hrtime": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tinyglobby": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "is-ip": "^5.0.1",
     "japanese-holidays": "^1.0.10",
     "jsonwebtoken": "^9.0.2",
     "lucide-react": "^0.535.0",


### PR DESCRIPTION
## 概要
- 公開認証系エンドポイントのレートリミットをIPバケット単位で強化し、監査ログとレスポンスの最小化で情報露出を抑制しました。

## 変更内容

- [ ] 新機能追加
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [x] テスト追加・修正
- [ ] 設定変更
- [x] その他: レートリミットと監査ログのセキュリティ強化

## やったこと
- `lib/api/rate-limiting.ts` をルール駆動の構成に刷新し、公開招待検証とLINEログイン向けのIPバケットを新設、レスポンスヘッダーにバケット情報を付加
- `middleware.ts` で全APIレスポンスにレートリミットヘッダーを付与しつつ、`OPTIONS` はレートリミットから除外して正規アクセスを阻害しないよう調整
- `lib/utils/request.ts` を新設し、IPとUser-Agent取得処理を共通化
- 招待検証/LINEログインAPIでトークンをマスクした監査ログを出力し、失敗時の情報露出を抑制
- `lib/api/__tests__/rate-limiting.test.ts` を拡充し、新バケットとルール分岐の挙動を検証

## やらないこと
- 永続ストアベースのレートリミット実装（Cloudflare KV 等）への移行
- LINEログインフロー以外の追加的な監査ログ整備

## 動作確認

- [ ] ローカル環境での動作確認完了
- [x] TypeScriptの型チェック通過 (`npm run typecheck`)
- [x] ESLintチェック通過 (`npm run lint`)
- [ ] テスト実行完了 (`npm test`)
- [ ] ビルド確認完了 (`npm run build`)

## 関連Issue
- なし

## スクリーンショット・動画
- なし

## レビューポイント
- レートリミットルール分岐がCloudflare Workers環境で問題なく動作するか
- 公開APIレスポンスの情報最小化が要求仕様を満たしているか

## 備考
- `npx jest lib/api/__tests__/rate-limiting.test.ts` を実行済みです
