### PR TITLE
:lock: Fix LINE login session cookie handling

### DIFF
--- a/__tests__/lib/utils/cookies.test.ts
+++ b/__tests__/lib/utils/cookies.test.ts
@@ -146,7 +146,7 @@ describe('setSessionCookie', () => {
     expect(mockResponse.cookies.set).toHaveBeenCalledWith('auth-session', sessionData, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
-      sameSite: 'strict',
+      sameSite: 'lax',
       maxAge: 10 * 60, // 10分間
       path: '/',
     });

--- a/lib/utils/cookies.ts
+++ b/lib/utils/cookies.ts
@@ -64,7 +64,7 @@ export function setSessionCookie(response: NextResponse, sessionData: string) {
     name: 'auth-session',
     value: sessionData,
     maxAge: 10 * 60, // 10分間（認証フロー完了まで）
-    sameSite: 'strict', // CSRF攻撃対策
+    sameSite: 'lax', // 外部IdPリダイレクト後のトップレベル遷移でも送信される必要がある
     httpOnly: true,
     secure: process.env.NODE_ENV === 'production',
   });


### PR DESCRIPTION
## 概要

LINEログイン後のコールバックでセッションCookieが送信されず、ログイン完了できない不具合を修正します。

## 変更内容

- [ ] 新機能追加
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [x] テスト追加・修正
- [ ] 設定変更
- [ ] その他:

## やったこと

- auth-session Cookie の SameSite を strict から lax に変更し、外部IdPリダイレクト後でもセッション情報が保持されるように調整
- Cookie テストの期待値を更新して新しい挙動を担保

## やらないこと

- 本番環境でのLINEログイン実機検証
- 認証トークン (auth-token) 設定の変更

## 動作確認

- [ ] ローカル環境での動作確認完了
- [x] TypeScriptの型チェック通過 (`npm run typecheck`)
- [x] ESLintチェック通過 (`npm run lint`)
- [x] テスト実行完了 (`npm test`)
- [ ] ビルド確認完了 (`npm run build`)

## 関連Issue

なし

## スクリーンショット・動画

なし

## レビューポイント

- SameSite を lax に変更したことで意図せずセッションが送信されるケースがないか
- テストの更新内容が妥当かどうか

## 備考

LINEのトップレベルリダイレクト後にもCSRF耐性を維持できるよう、短期セッションCookieのみ SameSite を緩和しています。
