### PR TITLE
🔧 Use wrangler NEXTAUTH_URL in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,22 @@ jobs:
         env:
           DATABASE_URL: ${{ env.PRISMA_DUMMY_DATABASE_URL }}
 
+      - name: Load NEXTAUTH_URL from wrangler.toml
+        run: |
+          python - <<'PY' >> "$GITHUB_ENV"
+          import tomllib
+          from pathlib import Path
+
+          with Path('wrangler.toml').open('rb') as f:
+            config = tomllib.load(f)
+
+          value = config.get('vars', {}).get('NEXTAUTH_URL')
+          if not value:
+            raise SystemExit('NEXTAUTH_URL not found in wrangler.toml')
+
+          print(f"NEXTAUTH_URL={value}")
+          PY
+
       - name: Build application with OpenNext Cloudflare
         run: npx @opennextjs/cloudflare build
         env:
@@ -43,7 +59,7 @@ jobs:
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
           LINE_CHANNEL_ID: ${{ vars.LINE_CHANNEL_ID }}
           LINE_CHANNEL_SECRET: ${{ secrets.LINE_CHANNEL_SECRET }}
-          NEXTAUTH_URL: ${{ secrets.NEXTAUTH_URL }}
+          NEXTAUTH_URL: ${{ env.NEXTAUTH_URL }}
 
       - name: Configure Cloudflare Workers runtime environment
         run: |
@@ -143,7 +159,7 @@ jobs:
     steps:
       - name: Health check
         env:
-          NEXTAUTH_URL: ${{ secrets.NEXTAUTH_URL }}
+          NEXTAUTH_URL: ${{ env.NEXTAUTH_URL }}
         run: |
           echo "Waiting for deployment to be available..."
           sleep 30


### PR DESCRIPTION
# プルリクエストテンプレート

## 概要

wrangler.toml に定義した NEXTAUTH_URL を GitHub Actions で読み込み、ビルドとヘルスチェックに渡すようにしました。

## 変更内容

- [ ] 新機能追加
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] テスト追加・修正
- [x] 設定変更
- [ ] その他:

## やったこと

- wrangler.toml から NEXTAUTH_URL を読み込んで GITHUB_ENV に設定するステップを追加
- Build とヘルスチェックで env.NEXTAUTH_URL のみを参照するよう変更

## やらないこと

- NEXTAUTH_URL を GitHub Secrets や Variables に登録する対応

## 動作確認

- [ ] ローカル環境での動作確認完了
- [x] TypeScriptの型チェック通過 (`npm run typecheck`)
- [x] ESLintチェック通過 (`npm run lint`)
- [ ] テスト実行完了 (`npm test`)
- [ ] ビルド確認完了 (`npm run build`)

## 関連Issue

なし

## スクリーンショット・動画

なし

## レビューポイント

- wrangler.toml の値を単一の情報源として扱う運用で問題ないか

## 備考

pre-push の自動チェックで typecheck / prettier / lint を実行済みです。
