### PR TITLE
♻️ Reuse NEXTAUTH_URL across workflow jobs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     if: github.repository == 'keichan110/snow-school-scheduler' # 意図しないforkでの実行防止
+    outputs:
+      nextauth_url: ${{ steps.load_nextauth_url.outputs.nextauth_url }}
     env:
       PRISMA_DUMMY_DATABASE_URL: file:./tmp/prisma-deploy.db # D1本番とは無関係なCI専用ダミー
 
@@ -36,8 +38,9 @@ jobs:
           DATABASE_URL: ${{ env.PRISMA_DUMMY_DATABASE_URL }}
 
       - name: Load NEXTAUTH_URL from wrangler.toml
+        id: load_nextauth_url
         run: |
-          python - <<'PY' >> "$GITHUB_ENV"
+          value=$(python - <<'PY'
           import tomllib
           from pathlib import Path
 
@@ -48,8 +51,11 @@ jobs:
           if not value:
             raise SystemExit('NEXTAUTH_URL not found in wrangler.toml')
 
-          print(f"NEXTAUTH_URL={value}")
+          print(value, end='')
           PY
+          )
+          echo "NEXTAUTH_URL=$value" >> "$GITHUB_ENV"
+          echo "nextauth_url=$value" >> "$GITHUB_OUTPUT"
 
       - name: Build application with OpenNext Cloudflare
         run: npx @opennextjs/cloudflare build
@@ -155,11 +161,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: deploy
     if: success()
+    env:
+      NEXTAUTH_URL: ${{ needs.deploy.outputs.nextauth_url }}
 
     steps:
       - name: Health check
-        env:
-          NEXTAUTH_URL: ${{ env.NEXTAUTH_URL }}
         run: |
           echo "Waiting for deployment to be available..."
           sleep 30


### PR DESCRIPTION
# プルリクエストテンプレート

## 概要

health-check ジョブでも wrangler.toml の NEXTAUTH_URL を参照できるよう、deploy ジョブから値を出力して受け渡すようにしました。

## 変更内容

- [ ] 新機能追加
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] テスト追加・修正
- [x] 設定変更
- [ ] その他:

## やったこと

- Load NEXTAUTH_URL ステップを出力付きに変更し、GITHUB_ENV とジョブ出力の両方へ値を設定
- health-check ジョブで needs.deploy.outputs.nextauth_url を参照して環境変数を注入

## やらないこと

- その他の環境変数やジョブ構成の変更

## 動作確認

- [ ] ローカル環境での動作確認完了
- [x] TypeScriptの型チェック通過 (`npm run typecheck`)
- [x] ESLintチェック通過 (`npm run lint`)
- [ ] テスト実行完了 (`npm test`)
- [ ] ビルド確認完了 (`npm run build`)

## 関連Issue

なし

## スクリーンショット・動画

なし

## レビューポイント

- deploy ジョブ出力の受け渡しで健康チェックが確実に wrangler.toml の値を参照できているか

## 備考

pre-push 自動チェックで typecheck / prettier / lint を実行済みです。
