### PR TITLE
:cloud: Update D1 deployment workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,11 +81,10 @@ jobs:
 
       - name: Apply database migrations
         id: migrate
-        run: npx prisma migrate deploy
+        run: npx wrangler d1 migrations apply snow-school-scheduler --remote
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          DATABASE_URL: 'wrangler://api.cloudflare.com/v4/accounts/${{ secrets.CLOUDFLARE_ACCOUNT_ID }}/d1/databases/${{ env.D1_DATABASE_ID }}'
 
       - name: Notify deployment status
         if: failure()

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -48,9 +48,9 @@ jobs:
         id: seed
         run: npx tsx prisma/seeds-prod/${{ github.event.inputs.seed_file }}
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_D1_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          DATABASE_URL: 'wrangler://api.cloudflare.com/v4/accounts/${{ secrets.CLOUDFLARE_ACCOUNT_ID }}/d1/databases/${{ env.D1_DATABASE_ID }}'
+          CLOUDFLARE_DATABASE_ID: ${{ env.D1_DATABASE_ID }}
 
       - name: Notify on failure
         if: failure()

--- a/prisma/seeds-prod/01_initial_master_data.ts
+++ b/prisma/seeds-prod/01_initial_master_data.ts
@@ -1,6 +1,34 @@
 import { PrismaClient } from '@prisma/client';
+import { PrismaD1 } from '@prisma/adapter-d1';
 
-const prisma = new PrismaClient();
+function createPrismaClient() {
+  const token = process.env.CLOUDFLARE_D1_TOKEN;
+  const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+  const databaseId = process.env.CLOUDFLARE_DATABASE_ID;
+
+  if (!token) {
+    throw new Error('CLOUDFLARE_D1_TOKEN が未設定です。');
+  }
+
+  if (!accountId) {
+    throw new Error('CLOUDFLARE_ACCOUNT_ID が未設定です。');
+  }
+
+  if (!databaseId) {
+    throw new Error('CLOUDFLARE_DATABASE_ID が未設定です。');
+  }
+
+  const adapter = new PrismaD1({
+    CLOUDFLARE_D1_TOKEN: token,
+    CLOUDFLARE_ACCOUNT_ID: accountId,
+    CLOUDFLARE_DATABASE_ID: databaseId,
+  });
+
+  console.log('Cloudflare D1 adapterを使用してPrismaに接続します...');
+  return new PrismaClient({ adapter });
+}
+
+const prisma = createPrismaClient();
 
 async function main() {
   console.log('スキー・スノーボードスクール プロダクションマスタデータ投入開始...\n');

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,6 +8,7 @@ compatibility_flags = ["nodejs_compat"]
 binding = "DB"
 database_name = "snow-school-scheduler"
 database_id = "a39eae08-e034-45a3-b85a-d7e9d1b57c30"
+migrations_dir = "prisma/migrations"
 
 # 静的アセット設定
 [assets]


### PR DESCRIPTION
## 概要

Cloudflare D1 向けのデプロイ／シード手順を統一し、Prisma の接続設定を正式なアダプター運用に切り替えました。

## 変更内容

- [ ] 新機能追加
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] テスト追加・修正
- [x] 設定変更
- [ ] その他:

## やったこと

- GitHub Actions のデプロイワークフローで Prisma CLI ではなく `wrangler d1 migrations apply` を使用するよう修正。
- `wrangler.toml` に `migrations_dir` を追加し、D1 マイグレーションディレクトリを明示。
- 本番用シードスクリプトを Cloudflare D1 アダプター専用に変更し、必須環境変数を簡素化。
- それに合わせて `seed.yml` の環境変数設定を整理。
- Prettier 対象から `.z/` ディレクトリを除外。

## やらないこと

- 本番以外のシードスクリプトやローカル開発向け設定の見直し。
- 画像最適化など既存 ESLint 警告への対応。

## 動作確認

- [ ] ローカル環境での動作確認完了
- [ ] TypeScriptの型チェック通過 (`npm run typecheck`)
- [ ] ESLintチェック通過 (`npm run lint`)
- [ ] テスト実行完了 (`npm test`)
- [ ] ビルド確認完了 (`npm run build`)

## 関連Issue

なし

## スクリーンショット・動画

該当なし

## レビューポイント

- D1 マイグレーション／シード実行フローが想定通り Cloudflare API を介して動作するか。
- 必須環境変数が漏れなく設定されているか。

## 備考

リモートリポジトリで pre-push フックが実行され、`.z/` 内のファイルが Prettier によって整形対象となっていたため `.prettierignore` に追記しています。
