### PR TITLE
Protect LINE callback logs and refresh first admin docs

### DIFF
--- a/app/api/auth/line/callback/route.ts
+++ b/app/api/auth/line/callback/route.ts
@@ -4,6 +4,7 @@ import { executeLineAuthFlow } from '@/lib/auth/line';
 import { generateJwt } from '@/lib/auth/jwt';
 import { validateInvitationToken, incrementTokenUsage } from '@/lib/auth/invitations';
 import { prisma } from '@/lib/db';
+import { secureAuthLog, secureLog } from '@/lib/utils/logging';
 
 /**
  * LINE認証コールバックAPI
@@ -41,7 +42,7 @@ export async function GET(request: NextRequest) {
     const error = searchParams.get('error');
     if (error) {
       const errorDescription = searchParams.get('error_description');
-      console.log('🚫 LINE authentication cancelled or failed:', {
+      secureLog('info', 'LINE authentication cancelled or failed', {
         error,
         description: errorDescription,
       });
@@ -57,7 +58,7 @@ export async function GET(request: NextRequest) {
     const receivedState = searchParams.get('state');
 
     if (!code || !receivedState) {
-      console.error('❌ Missing required callback parameters');
+      secureLog('error', 'Missing required LINE callback parameters');
       return NextResponse.redirect(new URL('/error?reason=invalid_callback', request.url), {
         status: 302,
       });
@@ -66,7 +67,7 @@ export async function GET(request: NextRequest) {
     // セッション情報の取得と検証
     const sessionCookie = request.cookies.get('auth-session')?.value;
     if (!sessionCookie) {
-      console.error('❌ Authentication session error');
+      secureLog('error', 'Authentication session cookie missing');
       return NextResponse.redirect(new URL('/error?reason=session_expired', request.url), {
         status: 302,
       });
@@ -76,7 +77,7 @@ export async function GET(request: NextRequest) {
     try {
       sessionData = JSON.parse(sessionCookie);
     } catch {
-      console.error('❌ Invalid session data format');
+      secureLog('error', 'Invalid authentication session data format');
       return NextResponse.redirect(new URL('/error?reason=invalid_session', request.url), {
         status: 302,
       });
@@ -85,13 +86,13 @@ export async function GET(request: NextRequest) {
     // セッション有効期限チェック（10分）
     const sessionAge = Date.now() - sessionData.createdAt;
     if (sessionAge > 10 * 60 * 1000) {
-      console.error('❌ Authentication session expired');
+      secureLog('error', 'Authentication session expired');
       return NextResponse.redirect(new URL('/error?reason=session_expired', request.url), {
         status: 302,
       });
     }
 
-    console.log('🔐 Processing LINE authentication callback:', {
+    secureAuthLog('Processing LINE authentication callback', {
       hasCode: true,
       hasState: true,
       hasInviteToken: !!sessionData.inviteToken,
@@ -102,13 +103,13 @@ export async function GET(request: NextRequest) {
     const authResult = await executeLineAuthFlow(code, receivedState, sessionData.state);
 
     if (!authResult.success || !authResult.profile) {
-      console.error('❌ LINE authentication flow failed');
+      secureLog('error', 'LINE authentication flow failed');
       return NextResponse.redirect(new URL('/error?reason=auth_failed', request.url), {
         status: 302,
       });
     }
 
-    console.log('✅ LINE authentication successful:', {
+    secureAuthLog('LINE authentication successful', {
       userId: authResult.profile.userId,
       displayName: authResult.profile.displayName,
       hasInviteToken: !!authResult.inviteToken,
@@ -123,7 +124,7 @@ export async function GET(request: NextRequest) {
 
     if (!user) {
       // 新規ユーザーの場合 - 招待トークン検証が必要
-      console.log('👤 Creating new user with invitation validation:', {
+      secureAuthLog('Creating new user with invitation validation', {
         lineUserId: authResult.profile.userId,
         displayName: authResult.profile.displayName,
         hasInviteToken: !!sessionData.inviteToken,
@@ -131,7 +132,7 @@ export async function GET(request: NextRequest) {
 
       // 招待トークンの検証
       if (!sessionData.inviteToken) {
-        console.error('❌ New user registration requires invitation token');
+        secureLog('error', 'New user registration requires invitation token');
         return NextResponse.redirect(new URL('/error?reason=invitation_required', request.url), {
           status: 302,
         });
@@ -140,7 +141,7 @@ export async function GET(request: NextRequest) {
       // 招待トークンの有効性チェック
       const tokenValidation = await validateInvitationToken(sessionData.inviteToken);
       if (!tokenValidation.isValid) {
-        console.error('❌ Invalid invitation token');
+        secureLog('error', 'Invalid invitation token');
 
         const errorReason =
           tokenValidation.errorCode === 'EXPIRED'
@@ -168,7 +169,7 @@ export async function GET(request: NextRequest) {
           },
         });
 
-        console.log('✅ New user created via invitation:', {
+        secureAuthLog('New user created via invitation', {
           id: user.id,
           role: user.role,
           inviteToken: sessionData.inviteToken.substring(0, 16) + '...',
@@ -177,20 +178,27 @@ export async function GET(request: NextRequest) {
         // 招待トークンの使用回数を増加
         try {
           await incrementTokenUsage(sessionData.inviteToken);
-          console.log('📊 Invitation token usage incremented successfully');
+          secureLog('info', 'Invitation token usage incremented successfully');
         } catch (incrementError) {
           // 使用回数増加に失敗してもユーザー作成は成功しているので警告レベル
-          console.warn('⚠️ Failed to increment invitation token usage:', incrementError);
+          secureLog('warn', 'Failed to increment invitation token usage', {
+            error:
+              incrementError instanceof Error
+                ? incrementError.message
+                : 'Unknown error while incrementing token usage',
+          });
         }
-      } catch {
-        console.error('❌ Failed to create user');
+      } catch (userCreationError) {
+        secureLog('error', 'Failed to create user', {
+          error: userCreationError instanceof Error ? userCreationError.message : undefined,
+        });
         return NextResponse.redirect(new URL('/error?reason=user_creation_failed', request.url), {
           status: 302,
         });
       }
     } else {
       // 既存ユーザーの場合
-      console.log('👤 Existing user login:', {
+      secureAuthLog('Existing user login', {
         id: user.id,
         displayName: user.displayName,
         role: user.role,
@@ -210,13 +218,13 @@ export async function GET(request: NextRequest) {
             profileImageUrl: authResult.profile.pictureUrl || null,
           },
         });
-        console.log('📝 Updated user profile (display name and/or image)');
+        secureLog('info', 'Updated user profile (display name and/or image)');
       }
     }
 
     // 非アクティブユーザーのチェック
     if (!user.isActive) {
-      console.warn('⚠️ Inactive user attempted login:', { userId: user.id });
+      secureLog('warn', 'Inactive user attempted login', { userId: user.id });
       return NextResponse.redirect(new URL('/error?reason=inactive_user', request.url), {
         status: 302,
       });
@@ -232,9 +240,7 @@ export async function GET(request: NextRequest) {
     };
 
     const token = generateJwt(jwtPayload);
-    if (process.env.NODE_ENV === 'development') {
-      console.log('🎫 JWT generated for user:', user.displayName);
-    }
+    secureLog('info', 'JWT generated for user', { displayName: user.displayName });
 
     // 認証成功レスポンスの作成（保存されたリダイレクト先を使用）
     const redirectPath = sessionData.redirectUrl || '/'; // デフォルトはホームページ
@@ -247,7 +253,7 @@ export async function GET(request: NextRequest) {
     // 認証セッションCookieの削除
     deleteCookie(response, 'auth-session');
 
-    console.log('🎉 Authentication completed successfully:', {
+    secureAuthLog('Authentication completed successfully', {
       userId: user.id,
       displayName: user.displayName,
       role: user.role,
@@ -255,8 +261,10 @@ export async function GET(request: NextRequest) {
     });
 
     return response;
-  } catch {
-    console.error('❌ Authentication callback failed');
+  } catch (error) {
+    secureLog('error', 'Authentication callback failed', {
+      error: error instanceof Error ? error.message : undefined,
+    });
 
     // システムエラー時のリダイレクト
     return NextResponse.redirect(new URL('/error?reason=system_error', request.url), {
@@ -278,7 +286,7 @@ export async function POST(request: NextRequest) {
     const error = formData.get('error')?.toString();
 
     if (error) {
-      console.log('🚫 LINE authentication cancelled (POST):', error);
+      secureLog('info', 'LINE authentication cancelled via POST callback', { error });
       return NextResponse.redirect(new URL('/error?reason=cancelled', request.url), {
         status: 302,
       });
@@ -297,8 +305,10 @@ export async function POST(request: NextRequest) {
 
     const modifiedRequest = new NextRequest(urlWithParams);
     return await GET(modifiedRequest);
-  } catch {
-    console.error('❌ POST callback processing failed');
+  } catch (error) {
+    secureLog('error', 'POST callback processing failed', {
+      error: error instanceof Error ? error.message : undefined,
+    });
     return NextResponse.redirect(new URL('/error?reason=system_error', request.url), {
       status: 302,
     });

--- a/middleware.ts
+++ b/middleware.ts
@@ -24,7 +24,7 @@ const PUBLIC_API_PREFIXES = [
 ];
 
 // 認証不要なページパス（完全一致）
-const PUBLIC_PAGE_PATHS = new Set(['/login', '/terms', '/privacy']);
+const PUBLIC_PAGE_PATHS = new Set(['/login', '/terms', '/privacy', '/error']);
 
 // 認証不要なページパス（プレフィックス一致）
 const PUBLIC_PAGE_PREFIXES = [


### PR DESCRIPTION
# プルリクエストテンプレート

## 概要

LINEコールバックのログ出力をセキュアログ経由に統一し、本番ログでLINE IDが出力されないようにしました。また、ファーストアドミン手順を開発環境でのID取得→本番DB投入のフローに更新しました。

## 変更内容

- [ ] 新機能追加
- [x] バグ修正
- [ ] リファクタリング
- [x] ドキュメント更新
- [ ] テスト追加・修正
- [ ] 設定変更
- [ ] その他:

## やったこと

- LINEコールバックAPIのログをsecureAuthLog/secureLogへ差し替え
- ファーストアドミン手順ドキュメントを現行仕様に沿って刷新

## やらないこと

- 招待トークン必須仕様の変更
- LINE認証フロー全体の挙動変更

## 動作確認

- [ ] ローカル環境での動作確認完了
- [x] TypeScriptの型チェック通過 (`npm run typecheck`)
- [x] ESLintチェック通過 (`npm run lint`)
- [ ] テスト実行完了 (`npm test`)
- [ ] ビルド確認完了 (`npm run build`)

## 関連Issue

なし

## スクリーンショット・動画

なし

## レビューポイント

- ログ出力の差し替えが既存機能に影響しないか
- ドキュメント手順が現状の運用と齟齬を起こしていないか

## 備考

pre-pushフックでtypecheckとlintのみ実行済みです。