### PR TITLE
💄 Unify buttons and page save actions

### DIFF
--- a/src/components/AppButton.tsx
+++ b/src/components/AppButton.tsx
@@ -1,0 +1,61 @@
+import {
+  Button,
+  polymorphicFactory,
+  type ButtonProps,
+  type PolymorphicFactory,
+} from '@mantine/core';
+
+type StandardIntent = 'primary' | 'secondary' | 'tertiary';
+
+type StandardButtonProps = {
+  /** 操作の意味と強調度。 */
+  intent: StandardIntent;
+  emphasis?: never;
+  compact?: never;
+};
+
+type DangerButtonProps = {
+  /** データの削除・停止・解除など、破壊的な操作を表す。 */
+  intent: 'danger';
+  /** 破壊操作への入口は low、最終確認は high を指定する。 */
+  emphasis?: 'low' | 'high';
+  /** 行内などの狭い場所で、淡い背景を付けずに表示する。 */
+  compact?: boolean;
+};
+
+export type AppButtonProps = Omit<ButtonProps, 'color' | 'variant'> &
+  (StandardButtonProps | DangerButtonProps);
+
+type AppButtonFactory = PolymorphicFactory<{
+  props: AppButtonProps;
+  defaultComponent: 'button';
+  defaultRef: HTMLButtonElement;
+}>;
+
+/**
+ * 操作の意味を Mantine の色と variant へ一貫して割り当てる共通ボタン。
+ */
+export const AppButton = polymorphicFactory<AppButtonFactory>(
+  ({ intent, emphasis, compact, ref, ...props }) => {
+    if (intent === 'danger') {
+      const highEmphasis = emphasis === 'high';
+
+      return (
+        <Button
+          ref={ref}
+          {...props}
+          color="red"
+          variant={highEmphasis ? 'filled' : compact ? 'subtle' : 'light'}
+        />
+      );
+    }
+
+    const variant = {
+      primary: 'filled',
+      secondary: 'default',
+      tertiary: 'subtle',
+    }[intent] satisfies ButtonProps['variant'];
+
+    return <Button ref={ref} {...props} variant={variant} />;
+  },
+);

--- a/src/components/FormFooterButtons.tsx
+++ b/src/components/FormFooterButtons.tsx
@@ -1,4 +1,6 @@
-import { Button, Group } from '@mantine/core';
+import { Group } from '@mantine/core';
+
+import { AppButton } from './AppButton';
 
 type FormFooterButtonsProps = {
   saving: boolean;
@@ -12,12 +14,12 @@ type FormFooterButtonsProps = {
 export function FormFooterButtons({ saving, onCancel }: FormFooterButtonsProps) {
   return (
     <Group justify="flex-end">
-      <Button variant="default" type="button" onClick={onCancel} disabled={saving}>
+      <AppButton intent="secondary" type="button" onClick={onCancel} disabled={saving}>
         キャンセル
-      </Button>
-      <Button type="submit" loading={saving}>
+      </AppButton>
+      <AppButton intent="primary" type="submit" loading={saving}>
         保存
-      </Button>
+      </AppButton>
     </Group>
   );
 }

--- a/src/components/UnsavedChangesBar.module.css
+++ b/src/components/UnsavedChangesBar.module.css
@@ -1,0 +1,26 @@
+.bar {
+  position: fixed;
+  z-index: 200;
+  inset-inline-end: 20px;
+  bottom: 20px;
+  width: min(680px, calc(100vw - var(--app-shell-navbar-offset, 0rem) - 40px));
+  background: color-mix(in srgb, var(--mantine-color-body) 94%, transparent);
+  backdrop-filter: blur(8px);
+}
+
+@media (max-width: 48em) {
+  .bar {
+    inset-inline-end: 10px;
+    bottom: 10px;
+    width: calc(100vw - 20px);
+  }
+
+  .content {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .actions {
+    justify-content: flex-end;
+  }
+}

--- a/src/components/UnsavedChangesBar.tsx
+++ b/src/components/UnsavedChangesBar.tsx
@@ -1,6 +1,7 @@
-import { Button, Group, Paper, Stack, Text } from '@mantine/core';
+import { Group, Paper, Stack, Text } from '@mantine/core';
 import { IconDeviceFloppy } from '@tabler/icons-react';
 
+import { AppButton } from './AppButton';
 import classes from './UnsavedChangesBar.module.css';
 
 type UnsavedChangesBarProps = {
@@ -33,12 +34,17 @@ export function UnsavedChangesBar({
           </Text>
         </Stack>
         <Group className={classes.actions} gap="xs" wrap="nowrap">
-          <Button variant="default" onClick={onCancel} disabled={loading}>
+          <AppButton intent="secondary" onClick={onCancel} disabled={loading}>
             キャンセル
-          </Button>
-          <Button leftSection={<IconDeviceFloppy size={18} />} onClick={onSave} loading={loading}>
+          </AppButton>
+          <AppButton
+            intent="primary"
+            leftSection={<IconDeviceFloppy size={18} />}
+            onClick={onSave}
+            loading={loading}
+          >
             {saveLabel}
-          </Button>
+          </AppButton>
         </Group>
       </Group>
     </Paper>

--- a/src/components/UnsavedChangesBar.tsx
+++ b/src/components/UnsavedChangesBar.tsx
@@ -1,0 +1,46 @@
+import { Button, Group, Paper, Stack, Text } from '@mantine/core';
+import { IconDeviceFloppy } from '@tabler/icons-react';
+
+import classes from './UnsavedChangesBar.module.css';
+
+type UnsavedChangesBarProps = {
+  count?: number;
+  description?: string;
+  loading?: boolean;
+  saveLabel?: string;
+  onCancel: () => void;
+  onSave: () => void;
+};
+
+/** 通常画面の未保存変更に対するキャンセル・保存操作を、画面下部へ共通表示する。 */
+export function UnsavedChangesBar({
+  count,
+  description = 'この画面の変更をまとめて保存します',
+  loading = false,
+  saveLabel = '変更を保存',
+  onCancel,
+  onSave,
+}: UnsavedChangesBarProps) {
+  const changeLabel = count === undefined ? '未保存の変更があります' : `未保存の変更 ${count}件`;
+
+  return (
+    <Paper className={classes.bar} withBorder shadow="lg" p="sm" role="region" aria-live="polite">
+      <Group className={classes.content} justify="space-between" wrap="nowrap">
+        <Stack gap={0}>
+          <Text fw={700}>{changeLabel}</Text>
+          <Text size="xs" c="dimmed">
+            {description}
+          </Text>
+        </Stack>
+        <Group className={classes.actions} gap="xs" wrap="nowrap">
+          <Button variant="default" onClick={onCancel} disabled={loading}>
+            キャンセル
+          </Button>
+          <Button leftSection={<IconDeviceFloppy size={18} />} onClick={onSave} loading={loading}>
+            {saveLabel}
+          </Button>
+        </Group>
+      </Group>
+    </Paper>
+  );
+}

--- a/src/features/availabilities/components/AvailabilityCalendar.tsx
+++ b/src/features/availabilities/components/AvailabilityCalendar.tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useState } from 'react';
 
 import {
   Box,
-  Button,
   Group,
   Menu,
   Modal,
@@ -24,6 +23,7 @@ import { useBlocker } from '@tanstack/react-router';
 import 'dayjs/locale/ja';
 
 import { ErrorAlert } from '@/components/AppAlert';
+import { AppButton } from '@/components/AppButton';
 import { UnsavedChangesBar } from '@/components/UnsavedChangesBar';
 import { addDays, todayString, toMonth, weekdayIndex } from '@/features/shifts/view-utils';
 
@@ -217,10 +217,12 @@ export function AvailabilityCalendar() {
             minRows={3}
           />
           <Group justify="flex-end">
-            <Button variant="default" onClick={() => setNoteDate(null)}>
+            <AppButton intent="secondary" onClick={() => setNoteDate(null)}>
               キャンセル
-            </Button>
-            <Button onClick={saveNote}>反映</Button>
+            </AppButton>
+            <AppButton intent="primary" onClick={saveNote}>
+              反映
+            </AppButton>
           </Group>
         </Stack>
       </Modal>
@@ -233,12 +235,12 @@ export function AvailabilityCalendar() {
         <Stack>
           <Text>このページを離れると、保存していない変更は失われます。</Text>
           <Group justify="flex-end">
-            <Button variant="default" onClick={() => blocker.reset?.()}>
+            <AppButton intent="secondary" onClick={() => blocker.reset?.()}>
               このページに残る
-            </Button>
-            <Button color="red" onClick={() => blocker.proceed?.()}>
+            </AppButton>
+            <AppButton intent="danger" emphasis="high" onClick={() => blocker.proceed?.()}>
               破棄して移動
-            </Button>
+            </AppButton>
           </Group>
         </Stack>
       </Modal>
@@ -251,12 +253,12 @@ export function AvailabilityCalendar() {
         <Stack>
           <Text>月を移動すると、保存していない変更は失われます。</Text>
           <Group justify="flex-end">
-            <Button variant="default" onClick={() => setPendingMonth(null)}>
+            <AppButton intent="secondary" onClick={() => setPendingMonth(null)}>
               この月に残る
-            </Button>
-            <Button color="red" onClick={discardChangesAndChangeMonth}>
+            </AppButton>
+            <AppButton intent="danger" emphasis="high" onClick={discardChangesAndChangeMonth}>
               破棄して移動
-            </Button>
+            </AppButton>
           </Group>
         </Stack>
       </Modal>

--- a/src/features/availabilities/components/AvailabilityCalendar.tsx
+++ b/src/features/availabilities/components/AvailabilityCalendar.tsx
@@ -24,6 +24,7 @@ import { useBlocker } from '@tanstack/react-router';
 import 'dayjs/locale/ja';
 
 import { ErrorAlert } from '@/components/AppAlert';
+import { UnsavedChangesBar } from '@/components/UnsavedChangesBar';
 import { addDays, todayString, toMonth, weekdayIndex } from '@/features/shifts/view-utils';
 
 import {
@@ -149,23 +150,15 @@ export function AvailabilityCalendar() {
         )}
       </Stack>
 
-      <Box pos="sticky" bottom={0} py="md" bg="var(--mantine-color-body)">
-        <Stack gap="xs">
-          {hasChanges && (
-            <Text size="sm" c="orange" ta="center">
-              未保存の変更 {changes.length} 件
-            </Text>
-          )}
-          <Button
-            fullWidth
-            disabled={!hasChanges}
-            loading={updateMutation.isPending}
-            onClick={() => void save()}
-          >
-            保存
-          </Button>
-        </Stack>
-      </Box>
+      {hasChanges && (
+        <UnsavedChangesBar
+          count={changes.length}
+          description="表示中の月の変更をまとめて保存します"
+          loading={updateMutation.isPending}
+          onCancel={() => setStaged(new Map())}
+          onSave={() => void save()}
+        />
+      )}
 
       {menu && (
         <Menu opened onChange={(opened) => !opened && setMenu(null)} position="bottom-start">

--- a/src/features/certification-requirements/components/CertificationRequirementSettings.tsx
+++ b/src/features/certification-requirements/components/CertificationRequirementSettings.tsx
@@ -18,7 +18,7 @@ import {
   IconGripVertical,
   IconListDetails,
   IconPlus,
-  IconX,
+  IconTrash,
 } from '@tabler/icons-react';
 
 import { ErrorAlert } from '@/components/AppAlert';
@@ -271,7 +271,7 @@ export function CertificationRankEditor({
                             setTierBlocks((current) => removeEmptyTier(current, block.id))
                           }
                         >
-                          <IconX size={16} />
+                          <IconTrash size={16} />
                         </ActionIcon>
                       </Group>
                     )}
@@ -324,7 +324,7 @@ export function CertificationRankEditor({
                                 )
                               }
                             >
-                              <IconX size={16} />
+                              <IconTrash size={16} />
                             </ActionIcon>
                           </Group>
                         </Group>

--- a/src/features/certification-requirements/components/CertificationRequirementSettings.tsx
+++ b/src/features/certification-requirements/components/CertificationRequirementSettings.tsx
@@ -22,6 +22,7 @@ import {
 } from '@tabler/icons-react';
 
 import { ErrorAlert } from '@/components/AppAlert';
+import { AppButton } from '@/components/AppButton';
 import { ListEmptyState } from '@/components/ListEmptyState';
 import { ListHeader } from '@/components/ListHeader';
 import { UnsavedChangesBar } from '@/components/UnsavedChangesBar';
@@ -337,13 +338,13 @@ export function CertificationRankEditor({
                   低
                 </Text>
               )}
-              <Button
-                variant="outline"
+              <AppButton
+                intent="tertiary"
                 leftSection={<IconPlus size={16} />}
                 onClick={() => setTierBlocks((current) => addEmptyTier(current, createBlockId()))}
               >
                 レベルを追加
-              </Button>
+              </AppButton>
               {isDirty && (
                 <UnsavedChangesBar
                   count={changedRequirementCount}

--- a/src/features/certification-requirements/components/CertificationRequirementSettings.tsx
+++ b/src/features/certification-requirements/components/CertificationRequirementSettings.tsx
@@ -24,6 +24,7 @@ import {
 import { ErrorAlert } from '@/components/AppAlert';
 import { ListEmptyState } from '@/components/ListEmptyState';
 import { ListHeader } from '@/components/ListHeader';
+import { UnsavedChangesBar } from '@/components/UnsavedChangesBar';
 import { useCertifications } from '@/features/certifications/queries';
 import { useDepartmentShiftTypes } from '@/features/department-shift-types/queries';
 import {
@@ -36,6 +37,7 @@ import { useCertificationRequirements, useUpdateCertificationRequirements } from
 import {
   addCertification,
   addEmptyTier,
+  countChangedRequirements,
   createTierBlocks,
   moveCertification,
   removeCertification,
@@ -147,6 +149,12 @@ export function CertificationRankEditor({
     () => createTierBlocks(savedCertifications ?? []),
     [savedCertifications],
   );
+  const savedRequirements = useMemo(() => serializeTierBlocks(savedTierBlocks), [savedTierBlocks]);
+  const currentRequirements = useMemo(() => serializeTierBlocks(tierBlocks), [tierBlocks]);
+  const isDirty =
+    savedCertifications !== undefined &&
+    JSON.stringify(currentRequirements) !== JSON.stringify(savedRequirements);
+  const changedRequirementCount = countChangedRequirements(savedRequirements, currentRequirements);
 
   useEffect(() => {
     if (savedCertifications) {
@@ -162,11 +170,8 @@ export function CertificationRankEditor({
       isHydratingRef.current = false;
       return;
     }
-    onDirtyChange?.(
-      JSON.stringify(serializeTierBlocks(tierBlocks)) !==
-        JSON.stringify(serializeTierBlocks(savedTierBlocks)),
-    );
-  }, [onDirtyChange, savedCertifications, savedTierBlocks, tierBlocks]);
+    onDirtyChange?.(isDirty);
+  }, [isDirty, onDirtyChange, savedCertifications]);
 
   const selectedCertificationIds = useMemo(
     () => new Set(tierBlocks.flatMap((block) => block.certificationIds)),
@@ -339,22 +344,28 @@ export function CertificationRankEditor({
               >
                 レベルを追加
               </Button>
-              <Button
-                loading={update.isPending}
-                onClick={() => {
-                  update.mutate(
-                    { certifications: serializeTierBlocks(tierBlocks) },
-                    {
-                      onSuccess: () => {
-                        onDirtyChange?.(false);
-                        notifications.show({ color: 'green', message: '必要資格を保存しました' });
+              {isDirty && (
+                <UnsavedChangesBar
+                  count={changedRequirementCount}
+                  description="選択中のシフト種別に必要な資格を保存します"
+                  loading={update.isPending}
+                  onCancel={() => setTierBlocks(savedTierBlocks)}
+                  onSave={() => {
+                    update.mutate(
+                      { certifications: currentRequirements },
+                      {
+                        onSuccess: () => {
+                          onDirtyChange?.(false);
+                          notifications.show({
+                            color: 'green',
+                            message: '必要資格を保存しました',
+                          });
+                        },
                       },
-                    },
-                  );
-                }}
-              >
-                保存
-              </Button>
+                    );
+                  }}
+                />
+              )}
               {update.isError && <ErrorAlert>{update.error.message}</ErrorAlert>}
             </Stack>
           )}

--- a/src/features/certification-requirements/tier-editor-state.ts
+++ b/src/features/certification-requirements/tier-editor-state.ts
@@ -100,6 +100,29 @@ export function serializeTierBlocks(blocks: TierBlock[]): CertificationRequireme
     );
 }
 
+/** 保存済み要件と編集中要件を比較し、追加・除外・レベル変更された資格数を返す。 */
+export function countChangedRequirements(
+  saved: CertificationRequirement[],
+  current: CertificationRequirement[],
+): number {
+  const savedRankByCertificationId = new Map(
+    saved.map(({ certificationId, tierRank }) => [certificationId, tierRank]),
+  );
+  const currentRankByCertificationId = new Map(
+    current.map(({ certificationId, tierRank }) => [certificationId, tierRank]),
+  );
+  const certificationIds = new Set([
+    ...savedRankByCertificationId.keys(),
+    ...currentRankByCertificationId.keys(),
+  ]);
+
+  return [...certificationIds].filter(
+    (certificationId) =>
+      savedRankByCertificationId.get(certificationId) !==
+      currentRankByCertificationId.get(certificationId),
+  ).length;
+}
+
 function cleanEmptyTiers(blocks: TierBlock[]): TierBlock[] {
   return blocks.filter((block) => block.certificationIds.length > 0 || block.preserveWhenEmpty);
 }

--- a/src/features/certifications/components/CertificationList.tsx
+++ b/src/features/certifications/components/CertificationList.tsx
@@ -1,11 +1,12 @@
 import { useMemo, useState } from 'react';
 
-import { Button, Menu, Stack, Table, Text } from '@mantine/core';
+import { Menu, Stack, Table, Text } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import { IconCertificate, IconPlus } from '@tabler/icons-react';
 
 import { ErrorAlert } from '@/components/AppAlert';
 import { AppBadge } from '@/components/AppBadge';
+import { AppButton } from '@/components/AppButton';
 import { AppTable } from '@/components/AppTable';
 import { ClickableTr } from '@/components/ClickableTr';
 import { InactiveVisibilityToggle } from '@/components/InactiveVisibilityToggle';
@@ -52,13 +53,14 @@ export function CertificationList() {
         summary={{ count: visibleCertifications.length, unit: '件' }}
         isLoading={isLoading}
         action={
-          <Button
+          <AppButton
+            intent="secondary"
             size="sm"
             leftSection={<IconPlus size={16} />}
             onClick={() => setDrawerState({ mode: 'create' })}
           >
             登録
-          </Button>
+          </AppButton>
         }
       />
 
@@ -81,12 +83,13 @@ export function CertificationList() {
           title="資格がありません"
           description="最初の資格を追加して管理を始めましょう。"
           action={
-            <Button
+            <AppButton
+              intent="primary"
               leftSection={<IconPlus size={16} />}
               onClick={() => setDrawerState({ mode: 'create' })}
             >
               登録
-            </Button>
+            </AppButton>
           }
         />
       )}

--- a/src/features/dashboard/components/InstructorLinkPrompt.tsx
+++ b/src/features/dashboard/components/InstructorLinkPrompt.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
 
-import { Button, Group, Modal, Select, Stack, Text } from '@mantine/core';
+import { Group, Modal, Select, Stack, Text } from '@mantine/core';
 
 import { WarningAlert } from '@/components/AppAlert';
+import { AppButton } from '@/components/AppButton';
 import { useLinkInstructor } from '@/features/auth/queries';
 import { useInstructors } from '@/features/instructors/queries';
 
@@ -33,9 +34,9 @@ export function InstructorLinkPrompt() {
         >
           <Group justify="space-between" align="center">
             <Text size="sm">連携すると、すべての機能が使えるようになります。</Text>
-            <Button type="button" variant="light" color="yellow" onClick={() => setOpened(true)}>
+            <AppButton intent="secondary" type="button" onClick={() => setOpened(true)}>
               連携する
-            </Button>
+            </AppButton>
           </Group>
         </WarningAlert>
       )}
@@ -60,7 +61,8 @@ export function InstructorLinkPrompt() {
               onChange={setSelectedId}
               flex={1}
             />
-            <Button
+            <AppButton
+              intent="primary"
               type="button"
               disabled={!selectedId}
               loading={linkInstructor.isPending}
@@ -71,7 +73,7 @@ export function InstructorLinkPrompt() {
               }}
             >
               連携する
-            </Button>
+            </AppButton>
           </Group>
           {linkInstructor.isError && (
             <Text c="red" size="sm">

--- a/src/features/department-shift-types/components/DepartmentShiftTypeList.tsx
+++ b/src/features/department-shift-types/components/DepartmentShiftTypeList.tsx
@@ -8,7 +8,7 @@ import {
   IconGripVertical,
   IconListDetails,
   IconPlus,
-  IconX,
+  IconTrash,
 } from '@tabler/icons-react';
 
 import { ErrorAlert } from '@/components/AppAlert';
@@ -261,7 +261,7 @@ function ShiftTypeRow({
             loading={isUpdating}
             onClick={onRemove}
           >
-            <IconX size={16} />
+            <IconTrash size={16} />
           </ActionIcon>
         </Group>
       </Group>

--- a/src/features/department-shift-types/components/DepartmentShiftTypeList.tsx
+++ b/src/features/department-shift-types/components/DepartmentShiftTypeList.tsx
@@ -1,11 +1,8 @@
-import { useRef, useState } from 'react';
-
 import { ActionIcon, Group, Paper, Stack, Text } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import {
   IconArrowDown,
   IconArrowUp,
-  IconGripVertical,
   IconListDetails,
   IconPlus,
   IconTrash,
@@ -38,8 +35,6 @@ export function DepartmentShiftTypeList({
   onAdd?: () => void;
   canRemove?: (shiftTypeId: string) => boolean;
 }) {
-  const dragSourceId = useRef<string | null>(null);
-  const [draggedId, setDraggedId] = useState<string | null>(null);
   const {
     data: departmentShiftTypes,
     isLoading,
@@ -64,27 +59,6 @@ export function DepartmentShiftTypeList({
     });
   };
 
-  const reorder = (targetId: string) => {
-    const sourceId = dragSourceId.current;
-    dragSourceId.current = null;
-    setDraggedId(null);
-    if (!sourceId || sourceId === targetId) return;
-
-    // ドロップ先の位置へ挿入した順序付き ID 配列を API に渡し、部門内の sort_order を一括更新する
-    const sourceIndex = items.findIndex((item) => item.shiftTypeId === sourceId);
-    const targetIndex = items.findIndex((item) => item.shiftTypeId === targetId);
-    if (sourceIndex < 0 || targetIndex < 0) return;
-
-    const reordered = [...items];
-    const [source] = reordered.splice(sourceIndex, 1);
-    if (!source) return;
-    reordered.splice(targetIndex, 0, source);
-    save(
-      reordered.map((item) => item.shiftTypeId),
-      '並び順を更新しました',
-    );
-  };
-
   const move = (shiftTypeId: string, offset: -1 | 1) => {
     const sourceIndex = items.findIndex((item) => item.shiftTypeId === shiftTypeId);
     const targetIndex = sourceIndex + offset;
@@ -105,7 +79,7 @@ export function DepartmentShiftTypeList({
       <Stack gap={4}>
         <Text fw={600}>{DEPARTMENT_LABELS[departmentCode]}部門で利用するシフト種別</Text>
         <Text c="dimmed" size="sm">
-          マスタから追加し、ドラッグまたは上下ボタンで表示順を変更できます。
+          マスタから追加し、上下ボタンで表示順を変更できます。
         </Text>
       </Stack>
 
@@ -131,17 +105,7 @@ export function DepartmentShiftTypeList({
             <ShiftTypeRow
               key={item.shiftTypeId}
               item={item}
-              isDragged={draggedId === item.shiftTypeId}
               isUpdating={update.isPending || removeMutation.isPending}
-              onDragStart={() => {
-                dragSourceId.current = item.shiftTypeId;
-                setDraggedId(item.shiftTypeId);
-              }}
-              onDragEnd={() => {
-                dragSourceId.current = null;
-                setDraggedId(null);
-              }}
-              onDrop={() => reorder(item.shiftTypeId)}
               onRemove={() => {
                 if (canRemove?.(item.shiftTypeId) === false) return;
                 remove(item.shiftTypeId, item.name);
@@ -171,11 +135,7 @@ export function DepartmentShiftTypeList({
 
 type ShiftTypeRowProps = {
   item: DepartmentShiftType;
-  isDragged: boolean;
   isUpdating: boolean;
-  onDragStart: () => void;
-  onDragEnd: () => void;
-  onDrop: () => void;
   onRemove: () => void;
   selected: boolean;
   onSelect: () => void;
@@ -185,14 +145,10 @@ type ShiftTypeRowProps = {
   onMoveDown: () => void;
 };
 
-/** ドラッグ操作と即時除外を提供する部門別シフト種別の1行。 */
+/** 上下移動と即時除外を提供する部門別シフト種別の1行。 */
 function ShiftTypeRow({
   item,
-  isDragged,
   isUpdating,
-  onDragStart,
-  onDragEnd,
-  onDrop,
   onRemove,
   selected,
   onSelect,
@@ -205,33 +161,14 @@ function ShiftTypeRow({
     <Paper
       withBorder
       p="sm"
-      opacity={isDragged ? 0.5 : 1}
       style={{
         cursor: isUpdating ? 'wait' : 'pointer',
         background: selected ? 'var(--mantine-color-blue-light)' : undefined,
       }}
-      onDragOver={(event) => event.preventDefault()}
-      onDrop={onDrop}
       onClick={onSelect}
     >
       <Group justify="space-between" wrap="nowrap">
         <Group gap="xs" wrap="nowrap">
-          <span
-            draggable={!isUpdating}
-            style={{ display: 'flex', cursor: 'grab' }}
-            onDragStart={(event) => {
-              event.stopPropagation();
-              onDragStart();
-            }}
-            onDragEnd={onDragEnd}
-            onClick={(event) => event.stopPropagation()}
-          >
-            <IconGripVertical
-              aria-label={`${item.name}を並び替え`}
-              size={18}
-              color="var(--mantine-color-dimmed)"
-            />
-          </span>
           <Text fw={500} size="sm">
             {item.name}
           </Text>

--- a/src/features/department-shift-types/components/DepartmentShiftTypeList.tsx
+++ b/src/features/department-shift-types/components/DepartmentShiftTypeList.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from 'react';
 
-import { ActionIcon, Button, Group, Paper, Stack, Text } from '@mantine/core';
+import { ActionIcon, Group, Paper, Stack, Text } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import {
   IconArrowDown,
@@ -13,6 +13,7 @@ import {
 
 import { ErrorAlert } from '@/components/AppAlert';
 import { AppBadge } from '@/components/AppBadge';
+import { AppButton } from '@/components/AppButton';
 import { ListEmptyState } from '@/components/ListEmptyState';
 import { DEPARTMENT_LABELS, type DepartmentCode } from '@/features/departments/schema';
 
@@ -157,9 +158,9 @@ export function DepartmentShiftTypeList({
       )}
 
       {onAdd && (
-        <Button variant="light" leftSection={<IconPlus size={16} />} onClick={onAdd}>
+        <AppButton intent="tertiary" leftSection={<IconPlus size={16} />} onClick={onAdd}>
           シフト種別を追加
-        </Button>
+        </AppButton>
       )}
 
       {update.isError && <ErrorAlert>{update.error.message}</ErrorAlert>}

--- a/src/features/health/components/HealthStatus.tsx
+++ b/src/features/health/components/HealthStatus.tsx
@@ -1,6 +1,7 @@
-import { Button, Card, Stack, Table, Text, Title } from '@mantine/core';
+import { Card, Stack, Table, Text, Title } from '@mantine/core';
 
 import { ErrorAlert } from '@/components/AppAlert';
+import { AppButton } from '@/components/AppButton';
 
 import { useHealth } from '../queries';
 
@@ -40,9 +41,9 @@ export function HealthStatus() {
           </Table>
         )}
 
-        <Button loading={isRefetching} onClick={() => refetch()}>
+        <AppButton intent="secondary" loading={isRefetching} onClick={() => refetch()}>
           再取得
-        </Button>
+        </AppButton>
       </Stack>
     </Card>
   );

--- a/src/features/instructors/components/InstructorList.tsx
+++ b/src/features/instructors/components/InstructorList.tsx
@@ -1,11 +1,12 @@
 import { useMemo, useState } from 'react';
 
-import { Avatar, Button, Group, Menu, Stack, Table, Text, Tooltip } from '@mantine/core';
+import { Avatar, Group, Menu, Stack, Table, Text, Tooltip } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import { IconPlus, IconUsers } from '@tabler/icons-react';
 
 import { ErrorAlert } from '@/components/AppAlert';
 import { AppBadge } from '@/components/AppBadge';
+import { AppButton } from '@/components/AppButton';
 import { AppTable } from '@/components/AppTable';
 import { ClickableTr } from '@/components/ClickableTr';
 import { InactiveVisibilityToggle } from '@/components/InactiveVisibilityToggle';
@@ -72,13 +73,14 @@ export function InstructorList() {
         summary={{ count: visibleInstructors.length, unit: '名' }}
         isLoading={isLoading}
         action={
-          <Button
+          <AppButton
+            intent="secondary"
             size="sm"
             leftSection={<IconPlus size={16} />}
             onClick={() => setDrawerState({ mode: 'create' })}
           >
             登録
-          </Button>
+          </AppButton>
         }
       />
 
@@ -101,12 +103,13 @@ export function InstructorList() {
           title="インストラクターがいません"
           description="最初のインストラクターを追加して名簿を作成しましょう。"
           action={
-            <Button
+            <AppButton
+              intent="primary"
               leftSection={<IconPlus size={16} />}
               onClick={() => setDrawerState({ mode: 'create' })}
             >
               登録
-            </Button>
+            </AppButton>
           }
         />
       )}

--- a/src/features/invitations/components/ActiveInvitationCard.tsx
+++ b/src/features/invitations/components/ActiveInvitationCard.tsx
@@ -13,6 +13,7 @@ import { notifications } from '@mantine/notifications';
 import { IconBan, IconCheck, IconClock, IconCopy, IconUsers } from '@tabler/icons-react';
 
 import { AppBadge } from '@/components/AppBadge';
+import { AppButton } from '@/components/AppButton';
 
 import { buildInviteUrl, formatDateTime, remainingLabel } from '../lib';
 import { useDeactivateInvitation } from '../queries';
@@ -57,23 +58,28 @@ export function ActiveInvitationCard({ invitation }: ActiveInvitationCardProps) 
 
           <Popover width={260} position="bottom-end" withArrow>
             <Popover.Target>
-              <Button variant="light" color="red" leftSection={<IconBan size={16} stroke={1.5} />}>
+              <AppButton
+                intent="danger"
+                emphasis="low"
+                leftSection={<IconBan size={16} stroke={1.5} />}
+              >
                 停止
-              </Button>
+              </AppButton>
             </Popover.Target>
             <Popover.Dropdown>
               <Stack gap="sm">
                 <Text size="sm">
                   この招待リンクを停止します。停止すると誰も使用できなくなり、元に戻せません。
                 </Text>
-                <Button
-                  color="red"
+                <AppButton
+                  intent="danger"
+                  emphasis="high"
                   fullWidth
                   loading={deactivate.isPending}
                   onClick={handleDeactivate}
                 >
                   停止する
-                </Button>
+                </AppButton>
               </Stack>
             </Popover.Dropdown>
           </Popover>

--- a/src/features/invitations/components/CreateInvitationModal.tsx
+++ b/src/features/invitations/components/CreateInvitationModal.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
 
-import { Button, Group, Input, Modal, SegmentedControl, Stack, TextInput } from '@mantine/core';
+import { Group, Input, Modal, SegmentedControl, Stack, TextInput } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import { IconAlertTriangle } from '@tabler/icons-react';
 
 import { ErrorAlert, WarningAlert } from '@/components/AppAlert';
+import { AppButton } from '@/components/AppButton';
 
 import { DEFAULT_EXPIRY_HOURS, EXPIRY_PRESETS } from '../lib';
 import { useCreateInvitation } from '../queries';
@@ -97,12 +98,12 @@ function CreateInvitationForm({ onClose, hasActiveInvitation }: CreateInvitation
         {create.isError && <ErrorAlert>{create.error.message}</ErrorAlert>}
 
         <Group justify="flex-end">
-          <Button variant="default" onClick={onClose}>
+          <AppButton intent="secondary" onClick={onClose}>
             キャンセル
-          </Button>
-          <Button type="submit" loading={create.isPending}>
+          </AppButton>
+          <AppButton intent="primary" type="submit" loading={create.isPending}>
             発行する
-          </Button>
+          </AppButton>
         </Group>
       </Stack>
     </form>

--- a/src/features/invitations/components/InvitationManager.tsx
+++ b/src/features/invitations/components/InvitationManager.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
 
-import { Button, EmptyState, Group, Skeleton, Stack, Text, Title } from '@mantine/core';
+import { EmptyState, Group, Skeleton, Stack, Text, Title } from '@mantine/core';
 import { IconLink } from '@tabler/icons-react';
 
 import { ErrorAlert } from '@/components/AppAlert';
+import { AppButton } from '@/components/AppButton';
 
 import { findActiveInvitation } from '../lib';
 import { useInvitations } from '../queries';
@@ -34,12 +35,13 @@ export function InvitationManager() {
             有効な招待リンクは常に1件のみです。新しく発行すると既存のリンクは自動的に置き換わります。
           </Text>
         </div>
-        <Button
+        <AppButton
+          intent="secondary"
           leftSection={<IconLink size={16} stroke={1.5} />}
           onClick={() => setModalOpened(true)}
         >
           招待リンクを発行
-        </Button>
+        </AppButton>
       </Group>
 
       {isLoading && (
@@ -60,12 +62,13 @@ export function InvitationManager() {
           description="招待リンクを発行してメンバーを招待しましょう。"
         >
           <EmptyState.Actions>
-            <Button
+            <AppButton
+              intent="primary"
               leftSection={<IconLink size={16} stroke={1.5} />}
               onClick={() => setModalOpened(true)}
             >
               招待リンクを発行
-            </Button>
+            </AppButton>
           </EmptyState.Actions>
         </EmptyState>
       )}

--- a/src/features/shift-types/components/ShiftTypeList.tsx
+++ b/src/features/shift-types/components/ShiftTypeList.tsx
@@ -1,10 +1,11 @@
 import { useMemo, useState, type ReactNode } from 'react';
 
-import { Button, Stack, Table, Text } from '@mantine/core';
+import { Stack, Table, Text } from '@mantine/core';
 import { IconClock, IconPlus } from '@tabler/icons-react';
 
 import { ErrorAlert } from '@/components/AppAlert';
 import { AppBadge } from '@/components/AppBadge';
+import { AppButton } from '@/components/AppButton';
 import { AppTable } from '@/components/AppTable';
 import { ClickableTr } from '@/components/ClickableTr';
 import { InactiveVisibilityToggle } from '@/components/InactiveVisibilityToggle';
@@ -60,7 +61,8 @@ export function ShiftTypeList({
         summary={{ count: visibleShiftTypes.length, unit: '件' }}
         isLoading={isLoading}
         action={
-          <Button
+          <AppButton
+            intent="secondary"
             size="sm"
             leftSection={<IconPlus size={16} />}
             onClick={() =>
@@ -68,7 +70,7 @@ export function ShiftTypeList({
             }
           >
             登録
-          </Button>
+          </AppButton>
         }
       />
 
@@ -91,14 +93,15 @@ export function ShiftTypeList({
           title="シフト種別がありません"
           description="最初のシフト種別をマスタに登録しましょう。"
           action={
-            <Button
+            <AppButton
+              intent="primary"
               leftSection={<IconPlus size={16} />}
               onClick={() =>
                 onOpenForm ? onOpenForm({ mode: 'create' }) : setDrawerState({ mode: 'create' })
               }
             >
               シフト種別を新規登録
-            </Button>
+            </AppButton>
           }
         />
       )}

--- a/src/features/shift-types/components/ShiftTypeSettings.tsx
+++ b/src/features/shift-types/components/ShiftTypeSettings.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useState } from 'react';
 
-import { Button, Drawer, Grid, Group, Modal, Paper, Stack, Tabs, Text } from '@mantine/core';
+import { Drawer, Grid, Group, Modal, Paper, Stack, Tabs, Text } from '@mantine/core';
 import { IconArrowLeft, IconDatabase } from '@tabler/icons-react';
 import { useBlocker } from '@tanstack/react-router';
 
+import { AppButton } from '@/components/AppButton';
 import { ListHeader } from '@/components/ListHeader';
 import { CertificationRankEditor } from '@/features/certification-requirements';
 import {
@@ -65,13 +66,13 @@ export function ShiftTypeSettings() {
       <ListHeader
         title="シフト種別設定"
         action={
-          <Button
-            variant="default"
+          <AppButton
+            intent="secondary"
             leftSection={<IconDatabase size={16} />}
             onClick={() => setCatalogOpened(true)}
           >
             シフト種別マスタを管理
-          </Button>
+          </AppButton>
         }
       />
       <Tabs value={departmentCode} onChange={changeDepartment}>
@@ -124,14 +125,14 @@ export function ShiftTypeSettings() {
       >
         {masterView ? (
           <Stack gap="md">
-            <Button
-              variant="subtle"
+            <AppButton
+              intent="tertiary"
               leftSection={<IconArrowLeft size={16} />}
               onClick={() => setMasterView(null)}
               style={{ alignSelf: 'flex-start' }}
             >
               一覧へ戻る
-            </Button>
+            </AppButton>
             <ShiftTypeDrawerContent state={masterView} onDone={() => setMasterView(null)} />
           </Stack>
         ) : (
@@ -148,12 +149,12 @@ export function ShiftTypeSettings() {
         <Stack>
           <Text>このページを離れると、保存していない必要資格の変更は失われます。</Text>
           <Group justify="flex-end">
-            <Button variant="default" onClick={() => blocker.reset?.()}>
+            <AppButton intent="secondary" onClick={() => blocker.reset?.()}>
               このページに残る
-            </Button>
-            <Button color="red" onClick={() => blocker.proceed?.()}>
+            </AppButton>
+            <AppButton intent="danger" emphasis="high" onClick={() => blocker.proceed?.()}>
               破棄して移動
-            </Button>
+            </AppButton>
           </Group>
         </Stack>
       </Modal>

--- a/src/features/shift-types/components/ShiftTypeSettings.tsx
+++ b/src/features/shift-types/components/ShiftTypeSettings.tsx
@@ -99,16 +99,9 @@ export function ShiftTypeSettings() {
         <Grid.Col span={{ base: 12, md: 8 }}>
           <Stack gap="xs">
             {selectedShiftTypeId && (
-              <Group justify="space-between">
-                <Text fw={600}>
-                  {shiftTypes?.find((item) => item.shiftTypeId === selectedShiftTypeId)?.name}
-                </Text>
-                {isEditorDirty && (
-                  <Text c="orange" size="sm">
-                    未保存の変更があります
-                  </Text>
-                )}
-              </Group>
+              <Text fw={600}>
+                {shiftTypes?.find((item) => item.shiftTypeId === selectedShiftTypeId)?.name}
+              </Text>
             )}
             <CertificationRankEditor
               key={`${departmentCode}:${selectedShiftTypeId ?? 'none'}`}

--- a/src/features/shifts/components/ShiftAgendaViewer.tsx
+++ b/src/features/shifts/components/ShiftAgendaViewer.tsx
@@ -20,6 +20,7 @@ import type { ScheduleEventData } from '@mantine/schedule';
 import { IconMessage, IconUserFilled } from '@tabler/icons-react';
 
 import { ErrorAlert, InfoAlert } from '@/components/AppAlert';
+import { AppButton } from '@/components/AppButton';
 import { useMe } from '@/features/auth/queries';
 import { getDepartmentAppearance } from '@/features/departments/appearance';
 import { departmentCodeSchema, type DepartmentCode } from '@/features/departments/schema';
@@ -168,17 +169,16 @@ export function ShiftAgendaViewer({ date, onVisibleDateChange }: ShiftAgendaView
           />
         </Group>
 
-        <Button
+        <AppButton
+          intent="tertiary"
           type="button"
-          variant="outline"
-          color="gray"
           size="sm"
           onClick={() => void loadPast()}
           loading={isLoadingPast}
           disabled={hasReachedPastEnd}
         >
           以前を表示
-        </Button>
+        </AppButton>
 
         {pastError && <ErrorAlert>{pastError}</ErrorAlert>}
         {hasReachedPastEnd && <InfoAlert>これ以上遡れるシフトはありません。</InfoAlert>}

--- a/src/features/shifts/components/ShiftManager.tsx
+++ b/src/features/shifts/components/ShiftManager.tsx
@@ -24,6 +24,7 @@ import {
 } from '@mantine/core';
 import { MonthView, type ScheduleEventData } from '@mantine/schedule';
 import { IconMessage, IconWand } from '@tabler/icons-react';
+import { useBlocker } from '@tanstack/react-router';
 
 import 'dayjs/locale/ja';
 
@@ -77,7 +78,9 @@ type StagedCell = {
 
 /** 部門・対象月変更をユーザー承認で確定するための保留アクション */
 type PendingNavigation =
-  { type: 'department'; nextDepartmentCode: DepartmentCode } | { type: 'month'; nextMonth: string };
+  | { type: 'department'; nextDepartmentCode: DepartmentCode }
+  | { type: 'month'; nextMonth: string }
+  | { type: 'shiftType'; nextShiftTypeId: string };
 
 /** シフト枠（日付 × 部門 × シフト種別）を月間シフト表で編集する管理コンポーネント。 */
 export function ShiftManager() {
@@ -113,6 +116,11 @@ export function ShiftManager() {
   const me = useMe();
   const days = useMemo(() => monthDays(month), [month]);
   const isDirty = stagedCells.size > 0;
+  const blocker = useBlocker({
+    shouldBlockFn: () => isDirty,
+    enableBeforeUnload: () => isDirty,
+    withResolver: true,
+  });
   const activeShiftTypeId = selectedCell?.shiftTypeId ?? formData.data?.shiftTypes[0]?.id ?? '';
   // シフト種別タブに「未保存の編集あり」のドットを出すため、ステージ済みセルの種別IDを集計する
   const stagedShiftTypeIds = useMemo(() => {
@@ -178,7 +186,25 @@ export function ShiftManager() {
     });
   }, [days, formData.data]);
 
-  /** 部門・対象月の遷移を要求する。dirty ならモーダルで確認、そうでなければ即時適用。 */
+  const applyNavigation = useCallback(
+    (nav: PendingNavigation) => {
+      if (nav.type === 'department') {
+        setDepartmentCode(nav.nextDepartmentCode);
+      } else if (nav.type === 'month') {
+        setMonth(nav.nextMonth);
+      } else {
+        setSelectedCell((current) => ({
+          date: current?.date ?? days[0] ?? todayString(),
+          shiftTypeId: nav.nextShiftTypeId,
+        }));
+      }
+      setStagedCells(new Map());
+      setDrawerOpened(false);
+    },
+    [days],
+  );
+
+  /** 画面内の表示切り替えを要求する。dirty ならモーダルで確認、そうでなければ即時適用する。 */
   const requestNavigation = useCallback(
     (nav: PendingNavigation) => {
       if (!isDirty) {
@@ -187,27 +213,22 @@ export function ShiftManager() {
       }
       setPendingNav(nav);
     },
-    [isDirty],
+    [applyNavigation, isDirty],
   );
-
-  const applyNavigation = (nav: PendingNavigation) => {
-    if (nav.type === 'department') {
-      setDepartmentCode(nav.nextDepartmentCode);
-    } else {
-      setMonth(nav.nextMonth);
-    }
-    setStagedCells(new Map());
-    setDrawerOpened(false);
-  };
 
   const confirmNavigation = () => {
     if (pendingNav) {
       applyNavigation(pendingNav);
+    } else {
+      blocker.proceed?.();
     }
     setPendingNav(null);
   };
 
-  const cancelNavigation = () => setPendingNav(null);
+  const cancelNavigation = () => {
+    setPendingNav(null);
+    blocker.reset?.();
+  };
 
   const stageCell = useCallback((cellKey: string, next: StagedCell) => {
     setStagedCells((prev) => {
@@ -276,10 +297,10 @@ export function ShiftManager() {
   // タブ切替: 選択中の日付は維持したままシフト種別だけを切り替える
   const changeActiveShiftType = useCallback(
     (shiftTypeId: string) => {
-      setSelectedCell((prev) => ({ date: prev?.date ?? days[0] ?? todayString(), shiftTypeId }));
-      setDrawerOpened(false);
+      if (shiftTypeId === activeShiftTypeId) return;
+      requestNavigation({ type: 'shiftType', nextShiftTypeId: shiftTypeId });
     },
-    [days],
+    [activeShiftTypeId, requestNavigation],
   );
 
   const openAssignmentDrawer = useCallback((cell: SelectedCell) => {
@@ -564,15 +585,21 @@ export function ShiftManager() {
       )}
 
       <Modal
-        opened={pendingNav !== null}
+        opened={pendingNav !== null || blocker.status === 'blocked'}
         onClose={cancelNavigation}
-        title="編集中の内容を破棄しますか？"
+        title="未保存の変更があります"
         centered
       >
         <Stack gap="md">
           <Text size="sm">
             未保存の変更が {stagedCells.size} 件あります。 このまま
-            {pendingNav?.type === 'department' ? '部門を切り替える' : '対象月を変更する'}
+            {pendingNav?.type === 'department'
+              ? '部門を切り替える'
+              : pendingNav?.type === 'month'
+                ? '対象月を変更する'
+                : pendingNav?.type === 'shiftType'
+                  ? 'シフト種別を切り替える'
+                  : '別のページへ移動する'}
             と、これらの変更は破棄されます。
           </Text>
           <Group justify="flex-end" gap="xs">
@@ -580,7 +607,7 @@ export function ShiftManager() {
               キャンセル
             </Button>
             <Button color="red" onClick={confirmNavigation}>
-              破棄して切り替え
+              破棄して移動
             </Button>
           </Group>
         </Stack>

--- a/src/features/shifts/components/ShiftManager.tsx
+++ b/src/features/shifts/components/ShiftManager.tsx
@@ -3,7 +3,6 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import {
   ActionIcon,
   Box,
-  Button,
   Card,
   Checkbox,
   Drawer,
@@ -30,6 +29,7 @@ import 'dayjs/locale/ja';
 
 import { ErrorAlert } from '@/components/AppAlert';
 import { AppBadge } from '@/components/AppBadge';
+import { AppButton } from '@/components/AppButton';
 import { UnsavedChangesBar } from '@/components/UnsavedChangesBar';
 import { useMe } from '@/features/auth/queries';
 import { useAvailabilities } from '@/features/availabilities/queries';
@@ -603,12 +603,12 @@ export function ShiftManager() {
             と、これらの変更は破棄されます。
           </Text>
           <Group justify="flex-end" gap="xs">
-            <Button variant="default" onClick={cancelNavigation}>
+            <AppButton intent="secondary" onClick={cancelNavigation}>
               キャンセル
-            </Button>
-            <Button color="red" onClick={confirmNavigation}>
+            </AppButton>
+            <AppButton intent="danger" emphasis="high" onClick={confirmNavigation}>
               破棄して移動
-            </Button>
+            </AppButton>
           </Group>
         </Stack>
       </Modal>
@@ -656,22 +656,23 @@ export function ShiftManager() {
           <Text size="xs" c="dimmed">
             必要資格は表示・判定に使用します。変更はシフト種別設定画面で行ってください。
           </Text>
-          <Button component="a" href="/shift-types" variant="subtle" size="xs">
+          <AppButton intent="tertiary" component="a" href="/shift-types" size="xs">
             必要資格設定を開く
-          </Button>
+          </AppButton>
           {autoAssignContext.data?.frames.find(
             (frame) => frame.shiftTypeId === autoAssignShiftTypeId,
           )?.certificationTiers.length === 0 && (
             <ErrorAlert>この種別には必要資格が設定されていないため、提案できません。</ErrorAlert>
           )}
-          <Button
+          <AppButton
+            intent={shortageByCell.size > 0 ? 'secondary' : 'primary'}
             leftSection={<IconWand size={16} />}
             onClick={runAutoAssign}
             loading={isAutoAssigning}
             disabled={!autoAssignContext.data || autoAssignDates.size === 0}
           >
             {shortageByCell.size > 0 ? '別の案を出す' : '提案をステージへ反映'}
-          </Button>
+          </AppButton>
         </Stack>
       </Modal>
     </Stack>
@@ -858,27 +859,28 @@ function ShiftCalendar({
               自動割当する日を選択（{autoAssignDates.size}日）
             </Text>
             <Group gap="xs">
-              <Button size="xs" variant="default" onClick={onCancelAutoAssign}>
+              <AppButton intent="secondary" size="xs" onClick={onCancelAutoAssign}>
                 キャンセル
-              </Button>
-              <Button
+              </AppButton>
+              <AppButton
+                intent="primary"
                 size="xs"
                 disabled={autoAssignDates.size === 0}
                 onClick={onOpenAutoAssignModal}
               >
                 条件設定
-              </Button>
+              </AppButton>
             </Group>
           </>
         ) : (
-          <Button
+          <AppButton
+            intent="secondary"
             size="xs"
-            variant="light"
             leftSection={<IconWand size={14} />}
             onClick={onStartAutoAssign}
           >
             自動割当
-          </Button>
+          </AppButton>
         )}
       </Group>
 

--- a/src/features/shifts/components/ShiftManager.tsx
+++ b/src/features/shifts/components/ShiftManager.tsx
@@ -29,6 +29,7 @@ import 'dayjs/locale/ja';
 
 import { ErrorAlert } from '@/components/AppAlert';
 import { AppBadge } from '@/components/AppBadge';
+import { UnsavedChangesBar } from '@/components/UnsavedChangesBar';
 import { useMe } from '@/features/auth/queries';
 import { useAvailabilities } from '@/features/availabilities/queries';
 import type { Availability } from '@/features/availabilities/schema';
@@ -451,33 +452,16 @@ export function ShiftManager() {
 
       {formData.data && (
         <>
-          <Group justify="flex-end" align="center" wrap="wrap">
-            <Group gap="xs">
-              {isDirty && (
-                <Text size="sm" c="orange">
-                  未保存の変更 {stagedCells.size} 件
-                </Text>
-              )}
-              <Button
-                type="button"
-                variant="default"
-                size="sm"
-                onClick={resetStage}
-                disabled={!isDirty || upsertMonthly.isPending}
-              >
-                クリア
-              </Button>
-              <Button
-                type="button"
-                size="sm"
-                onClick={saveMonthly}
-                loading={upsertMonthly.isPending}
-                disabled={!isDirty}
-              >
-                一括保存
-              </Button>
-            </Group>
-          </Group>
+          {isDirty && (
+            <UnsavedChangesBar
+              count={stagedCells.size}
+              description="表示中の月のシフト割当をまとめて保存します"
+              loading={upsertMonthly.isPending}
+              saveLabel="一括保存"
+              onCancel={resetStage}
+              onSave={saveMonthly}
+            />
+          )}
 
           {upsertMonthly.isError && (
             <ErrorAlert>{upsertMonthly.error?.message ?? '保存に失敗しました'}</ErrorAlert>

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -2,7 +2,6 @@ import {
   AppShell,
   Avatar,
   Burger,
-  Button,
   Container,
   Divider,
   Drawer,
@@ -34,6 +33,7 @@ import {
   useRouterState,
 } from '@tanstack/react-router';
 
+import { AppButton } from '@/components/AppButton';
 import { useLogout, useMe, useUnlinkInstructor } from '@/features/auth/queries';
 import { hasMinimumRole, type MeResponse } from '@/features/auth/schema';
 import { InstructorLinkPrompt } from '@/features/dashboard/components/InstructorLinkPrompt';
@@ -273,9 +273,8 @@ function MobileAccountActions({ user }: { user: MeResponse }) {
           <MobileInstructorLinkSection instructorId={user.instructorId} />
         </>
       )}
-      <Button
-        color="red"
-        variant="subtle"
+      <AppButton
+        intent="tertiary"
         justify="flex-start"
         loading={logout.isPending}
         onClick={() => {
@@ -284,7 +283,7 @@ function MobileAccountActions({ user }: { user: MeResponse }) {
         }}
       >
         ログアウト
-      </Button>
+      </AppButton>
     </Stack>
   );
 }
@@ -300,16 +299,16 @@ function MobileInstructorLinkSection({ instructorId }: { instructorId: string })
         <Text size="sm" truncate flex={1}>
           {instructor ? `${instructor.lastName} ${instructor.firstName}` : '連携情報を読み込み中'}
         </Text>
-        <Button
+        <AppButton
+          intent="danger"
+          compact
           type="button"
-          variant="subtle"
-          color="red"
           size="compact-xs"
           loading={unlinkInstructor.isPending}
           onClick={() => unlinkInstructor.mutate()}
         >
           連携解除
-        </Button>
+        </AppButton>
       </Group>
       {unlinkInstructor.isError && (
         <Text c="red" size="xs">
@@ -368,16 +367,16 @@ function InstructorLinkMenuSection({ instructorId }: { instructorId: string }) {
         <Text size="sm" truncate flex={1}>
           {instructor ? `${instructor.lastName} ${instructor.firstName}` : '連携情報を読み込み中'}
         </Text>
-        <Button
+        <AppButton
+          intent="danger"
+          compact
           type="button"
-          variant="subtle"
-          color="red"
           size="compact-xs"
           loading={unlinkInstructor.isPending}
           onClick={() => unlinkInstructor.mutate()}
         >
           解除
-        </Button>
+        </AppButton>
       </Group>
       {unlinkInstructor.isError && (
         <Text c="red" size="xs" px="sm" pt="xs">

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,6 +1,7 @@
-import { Button, Card, Container, Group, Stack, Text, Title } from '@mantine/core';
+import { Card, Container, Group, Stack, Text, Title } from '@mantine/core';
 import { createFileRoute, Link, redirect } from '@tanstack/react-router';
 
+import { AppButton } from '@/components/AppButton';
 import { ensureAuthenticated } from '@/features/auth/auth-guard';
 import { useMe } from '@/features/auth/queries';
 import { UpcomingShifts } from '@/features/dashboard/components/UpcomingShifts';
@@ -39,9 +40,9 @@ function DashboardPage() {
                     勤務できない日や調整が必要な日を登録します。
                   </Text>
                 </Stack>
-                <Button component={Link} to="/availabilities" variant="outline">
+                <AppButton intent="secondary" component={Link} to="/availabilities">
                   シフト希望を入力
-                </Button>
+                </AppButton>
               </Group>
             </Card>
           </>

--- a/test/certification-tier-editor-state.test.ts
+++ b/test/certification-tier-editor-state.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   addCertification,
   addEmptyTier,
+  countChangedRequirements,
   createTierBlocks,
   moveCertification,
   removeCertification,
@@ -84,5 +85,20 @@ describe('tier editor state', () => {
       { certificationId: 'b', tierRank: 2 },
       { certificationId: 'c', tierRank: 2 },
     ]);
+  });
+
+  it('追加・除外・レベル変更された資格の件数を数える', () => {
+    const saved = [
+      { certificationId: 'a', tierRank: 1 },
+      { certificationId: 'b', tierRank: 1 },
+      { certificationId: 'c', tierRank: 2 },
+    ];
+    const current = [
+      { certificationId: 'a', tierRank: 2 },
+      { certificationId: 'b', tierRank: 1 },
+      { certificationId: 'd', tierRank: 2 },
+    ];
+
+    expect(countChangedRequirements(saved, current)).toBe(3);
   });
 });


### PR DESCRIPTION
## 概要

ボタンの見た目とページの未保存保存操作をアプリ全体で統一しました。あわせて未保存警告の対象範囲を広げ、操作体験を揃えます。

## やったこと

- 通常画面の未保存操作を右下の共通バー（UnsavedChangesBar）へ統一（モーダル・ドロワーは対象外）
- シフト種別切り替えとページ遷移にも未保存警告を追加し、月・部門切り替えと同じ確認体験に統一
- 操作の意味と強調度に基づきボタンスタイルを共通化（AppButton を導入）
- 削除・除外系ボタンをゴミ箱アイコンに統一
- 部門別シフト種別の並べ替えを上下ボタン方式に戻し、ドラッグ操作を除去

## レビューポイント

- 未保存バーの表示条件（変更時のみ件数・キャンセル・保存を表示、モーダル/ドロワーは対象外）が意図どおりか

## 備考

- UI/UX の変更を含みます
