### PR TITLE
🐛 Fix navigation blocker priority

### DIFF
--- a/src/features/shifts/components/ShiftManager.tsx
+++ b/src/features/shifts/components/ShiftManager.tsx
@@ -121,6 +121,13 @@ export function ShiftManager() {
     enableBeforeUnload: () => isDirty,
     withResolver: true,
   });
+
+  useEffect(() => {
+    if (blocker.status === 'blocked') {
+      setPendingNav(null);
+    }
+  }, [blocker.status]);
+
   const activeShiftTypeId = selectedCell?.shiftTypeId ?? formData.data?.shiftTypes[0]?.id ?? '';
   // シフト種別タブに「未保存の編集あり」のドットを出すため、ステージ済みセルの種別IDを集計する
   const stagedShiftTypeIds = useMemo(() => {
@@ -217,10 +224,10 @@ export function ShiftManager() {
   );
 
   const confirmNavigation = () => {
-    if (pendingNav) {
-      applyNavigation(pendingNav);
-    } else {
+    if (blocker.status === 'blocked') {
       blocker.proceed?.();
+    } else if (pendingNav) {
+      applyNavigation(pendingNav);
     }
     setPendingNav(null);
   };


### PR DESCRIPTION
## 概要

シフト管理画面で、画面内遷移（部門・月・シフト種別の切り替え）とページ離脱（ルーターの blocker）が同時に発生した際、破棄確認で画面内遷移が優先され、離脱が実行されないバグを修正する。

## やったこと

- `confirmNavigation` で `blocker.status === 'blocked'` を最優先で判定し、ページ離脱を確定させる
- blocker が発火したら残っている `pendingNav` をクリアし、離脱と画面内遷移の競合を防ぐ
