### PR TITLE
💄 Highlight holidays in calendars

### DIFF
--- a/src/features/availabilities/components/AvailabilityCalendar.tsx
+++ b/src/features/availabilities/components/AvailabilityCalendar.tsx
@@ -25,7 +25,7 @@ import 'dayjs/locale/ja';
 import { ErrorAlert } from '@/components/AppAlert';
 import { AppButton } from '@/components/AppButton';
 import { UnsavedChangesBar } from '@/components/UnsavedChangesBar';
-import { addDays, todayString, toMonth, weekdayIndex } from '@/features/shifts/view-utils';
+import { addDays, getCalendarDayColor, todayString, toMonth } from '@/features/shifts/view-utils';
 
 import {
   buildAvailabilityChanges,
@@ -362,6 +362,7 @@ function AvailabilityMonthView({
       viewSelectProps={{ views: ['month'], style: { display: 'none' } }}
       getDayProps={(date) => {
         const editability = getDateEditability(date, today, lockedDates);
+        const calendarDayColor = getCalendarDayColor(date);
         const disabled = editability !== 'editable';
         const disabledReason =
           editability === 'locked'
@@ -380,12 +381,7 @@ function AvailabilityMonthView({
           title: disabledReason,
           disabled,
           style: {
-            color:
-              weekdayIndex(date) === 0
-                ? 'var(--mantine-color-red-7)'
-                : weekdayIndex(date) === 6
-                  ? 'var(--mantine-color-blue-7)'
-                  : undefined,
+            color: calendarDayColor ? `var(--mantine-color-${calendarDayColor}-7)` : undefined,
           },
         };
       }}

--- a/src/features/dashboard/components/UpcomingShifts.tsx
+++ b/src/features/dashboard/components/UpcomingShifts.tsx
@@ -10,7 +10,12 @@ import { departmentCodeSchema, type DepartmentCode } from '@/features/department
 import { ShiftAttendeeRow } from '@/features/shifts/components/ShiftAttendeeRow';
 import { useShiftAttendance, useShifts } from '@/features/shifts/queries';
 import type { ShiftViewItem } from '@/features/shifts/schema';
-import { formatDate, shortDateLabel, todayString } from '@/features/shifts/view-utils';
+import {
+  formatDate,
+  getCalendarDayColor,
+  shortDateLabel,
+  todayString,
+} from '@/features/shifts/view-utils';
 
 import classes from './UpcomingShifts.module.css';
 
@@ -152,26 +157,21 @@ export function UpcomingShifts({ instructorId }: { instructorId: string }) {
   }
 
   /**
-   * 勤務がない日の曜日文字色を日本式（日曜=赤・土曜=青）で返す。
+   * 勤務がない日の曜日・祝日文字色を日本式（日曜・祝日=赤、土曜=青）で返す。
    * 平日は何も返さない
    */
   const getWeekendDayProps = (date: string) => {
-    const dayOfWeek = dayjs(date).day();
-    if (dayOfWeek === 0) {
-      return { style: { color: 'var(--mantine-color-red-6)' } };
-    }
-    if (dayOfWeek === 6) {
-      return { style: { color: 'var(--mantine-color-blue-6)' } };
-    }
-    return {};
+    const color = getCalendarDayColor(date);
+    return color ? { style: { color: `var(--mantine-color-${color}-6)` } } : {};
   };
 
   /**
    * カレンダーの日セルに部門色の背景と勤務可用性の記号を当てる。
-   * 勤務部門が0件なら曜日に応じた日本式の週末文字色（土曜=青・日曜=赤）、
+   * 祝日は勤務予定の有無にかかわらず赤字にする。勤務部門が0件なら、
+   * 曜日に応じた日本式の週末文字色（土曜=青・日曜=赤）も適用する。
    * 1件ならその部門色で塗り、2件（ski・snowboard）なら45°の対角スプリット背景で
    * 両方を表現する。勤務可用性は勤務の有無にかかわらず右上へ重ねる。
-   * 勤務日は部門色の背景が主役のため週末色は当てない。
+   * 勤務日は部門色の背景を優先するが、祝日の赤字表示は維持する。
    * 色は Mantine のセマンティック CSS 変数（`-light` / `-light-color`）経由で指定し、
    * ライト/ダーク双方のテーマに追従させる。
    */
@@ -205,7 +205,10 @@ export function UpcomingShifts({ instructorId }: { instructorId: string }) {
         ...availabilityProps,
         style: {
           backgroundColor: `var(--mantine-color-${color}-light)`,
-          color: `var(--mantine-color-${color}-light-color)`,
+          color:
+            getCalendarDayColor(date) === 'red'
+              ? 'var(--mantine-color-red-6)'
+              : `var(--mantine-color-${color}-light-color)`,
         },
       };
     }
@@ -215,6 +218,7 @@ export function UpcomingShifts({ instructorId }: { instructorId: string }) {
       ...availabilityProps,
       style: {
         backgroundImage: `linear-gradient(135deg, var(--mantine-color-${firstColor}-light) 50%, var(--mantine-color-${secondColor}-light) 50%)`,
+        color: getCalendarDayColor(date) === 'red' ? 'var(--mantine-color-red-6)' : undefined,
       },
     };
   };

--- a/src/features/shifts/components/ShiftAgendaViewer.module.css
+++ b/src/features/shifts/components/ShiftAgendaViewer.module.css
@@ -7,6 +7,15 @@
   padding-block: 8px;
 }
 
+/* AgendaView は日付見出しの個別描画を差し替えられないため、同日イベントの属性から色を適用する。 */
+.agendaDateGroup:has([data-agenda-day-color='red']) > :first-child {
+  color: var(--mantine-color-red-7);
+}
+
+.agendaDateGroup:has([data-agenda-day-color='blue']) > :first-child {
+  color: var(--mantine-color-blue-7);
+}
+
 /* AgendaView の標準イベントと同じく、左端バーで部門を識別する */
 .eventBody {
   display: flex;

--- a/src/features/shifts/components/ShiftAgendaViewer.tsx
+++ b/src/features/shifts/components/ShiftAgendaViewer.tsx
@@ -26,7 +26,7 @@ import { departmentCodeSchema, type DepartmentCode } from '@/features/department
 import { containsInstructorAssignment, filterAgendaDaysByInstructor } from '../aggregators';
 import { fetchShiftAgendaPage, useShiftAgendaFuture } from '../queries';
 import type { ShiftAgendaDay, ShiftAgendaResponse, ShiftViewItem } from '../schema';
-import { addDays, addMonths, shortDateLabel, toMonth } from '../view-utils';
+import { addDays, addMonths, getCalendarDayColor, shortDateLabel, toMonth } from '../view-utils';
 import classes from './ShiftAgendaViewer.module.css';
 import { ShiftAttendeeRow } from './ShiftAttendeeRow';
 
@@ -302,6 +302,7 @@ function AgendaDayList({
             mode="static"
             dateHeaderFormat={(date) => shortDateLabel(date.slice(0, 10))}
             styles={{ agendaViewHeader: { display: 'none' } }}
+            classNames={{ agendaViewDateGroup: classes.agendaDateGroup }}
             renderEvent={(event, props) => {
               // AgendaView の payload は汎用型のため、ここで自前の型へ絞り込む
               // （events はこのコンポーネント自身が組み立てているため安全）
@@ -310,6 +311,7 @@ function AgendaDayList({
                 <UnstyledButton
                   {...props}
                   data-agenda-date={payload.shift.date}
+                  data-agenda-day-color={getCalendarDayColor(payload.shift.date)}
                   display="block"
                   w="100%"
                 >

--- a/src/features/shifts/components/ShiftManager.tsx
+++ b/src/features/shifts/components/ShiftManager.tsx
@@ -48,7 +48,14 @@ import {
   useUpsertAssignments,
 } from '../queries';
 import type { AutoAssignProposal, AvailableInstructor, ShiftViewItem } from '../schema';
-import { addDays, shortDateLabel, todayString, toMonth, weekdayIndex } from '../view-utils';
+import {
+  addDays,
+  getCalendarDayColor,
+  shortDateLabel,
+  todayString,
+  toMonth,
+  weekdayIndex,
+} from '../view-utils';
 import { calculateFairShare, countCurrentMonthWorkDays, type CellAssignment } from '../workload';
 import { applyAutoAssignProposals } from './auto-assign-stage';
 import {
@@ -425,6 +432,7 @@ export function ShiftManager() {
   const selectedStagedCell = selectedCell
     ? stagedCells.get(cellKey(selectedCell.date, selectedCell.shiftTypeId))
     : undefined;
+  const selectedCellDateColor = selectedCell ? getCalendarDayColor(selectedCell.date) : undefined;
   const selectedServerShift = selectedCell
     ? monthly.data?.shifts.find(
         (shift) =>
@@ -539,7 +547,13 @@ export function ShiftManager() {
               selectedCell ? (
                 <Group justify="space-between" wrap="nowrap" w="100%">
                   <Stack gap={0}>
-                    <Text fw={600}>{shortDateLabel(selectedCell.date)}</Text>
+                    {selectedCellDateColor ? (
+                      <Text fw={600} c={selectedCellDateColor}>
+                        {shortDateLabel(selectedCell.date)}
+                      </Text>
+                    ) : (
+                      <Text fw={600}>{shortDateLabel(selectedCell.date)}</Text>
+                    )}
                     <Text size="xs" c="dimmed" fw={400}>
                       {formData.data.shiftTypes.find(
                         (shiftType) => shiftType.id === selectedCell.shiftTypeId,
@@ -920,18 +934,14 @@ function ShiftCalendar({
         getDayProps={(date) => {
           const selected =
             selectedCell?.date === date && selectedCell.shiftTypeId === activeShiftTypeId;
+          const calendarDayColor = getCalendarDayColor(date);
           return {
             'data-shift-date': date,
             'data-selected': selected || undefined,
             'data-staged': stagedCells.has(cellKey(date, activeShiftTypeId)) || undefined,
             'aria-label': `${Number(date.slice(5, 7))}月${Number(date.slice(8, 10))}日（${weekdayLabel(date)}）の割り当てを編集`,
             style: {
-              color:
-                weekdayIndex(date) === 0
-                  ? 'var(--mantine-color-red-7)'
-                  : weekdayIndex(date) === 6
-                    ? 'var(--mantine-color-blue-7)'
-                    : undefined,
+              color: calendarDayColor ? `var(--mantine-color-${calendarDayColor}-7)` : undefined,
               backgroundColor:
                 autoAssignMode && autoAssignDates.has(date)
                   ? 'var(--mantine-color-blue-0)'

--- a/src/features/shifts/components/ShiftManager.tsx
+++ b/src/features/shifts/components/ShiftManager.tsx
@@ -547,13 +547,9 @@ export function ShiftManager() {
               selectedCell ? (
                 <Group justify="space-between" wrap="nowrap" w="100%">
                   <Stack gap={0}>
-                    {selectedCellDateColor ? (
-                      <Text fw={600} c={selectedCellDateColor}>
-                        {shortDateLabel(selectedCell.date)}
-                      </Text>
-                    ) : (
-                      <Text fw={600}>{shortDateLabel(selectedCell.date)}</Text>
-                    )}
+                    <Text fw={600} {...(selectedCellDateColor ? { c: selectedCellDateColor } : {})}>
+                      {shortDateLabel(selectedCell.date)}
+                    </Text>
                     <Text size="xs" c="dimmed" fw={400}>
                       {formData.data.shiftTypes.find(
                         (shiftType) => shiftType.id === selectedCell.shiftTypeId,

--- a/src/features/shifts/view-utils.ts
+++ b/src/features/shifts/view-utils.ts
@@ -1,3 +1,5 @@
+import JapaneseHolidays from 'japanese-holidays';
+
 /**
  * 表示ビュー（週次/月次）の日付計算ユーティリティ。
  * 期間計算・整形は UTC 基準で行い、サーバー側の日付正規化（`T00:00:00.000Z`）と一致させる。
@@ -50,6 +52,25 @@ export const WEEKDAY_LABELS = ['日', '月', '火', '水', '木', '金', '土'] 
 /** YYYY-MM-DD の曜日インデックス（0=日）を返す */
 export function weekdayIndex(dateStr: string): number {
   return parseDate(dateStr).getUTCDay();
+}
+
+/** YYYY-MM-DD が日本の祝日または振替休日かを判定する。 */
+export function isJapaneseHoliday(dateStr: string): boolean {
+  const year = Number(dateStr.slice(0, 4));
+  const month = Number(dateStr.slice(5, 7));
+  const day = Number(dateStr.slice(8, 10));
+  return Boolean(JapaneseHolidays.isHoliday(new Date(year, month - 1, day)));
+}
+
+/** 日本式カレンダーにおける日付文字色を返す（日曜・祝日=赤、土曜=青）。 */
+export function getCalendarDayColor(dateStr: string): 'red' | 'blue' | undefined {
+  if (isJapaneseHoliday(dateStr) || weekdayIndex(dateStr) === 0) {
+    return 'red';
+  }
+  if (weekdayIndex(dateStr) === 6) {
+    return 'blue';
+  }
+  return undefined;
 }
 
 /** 「M/D（曜）」形式の短い日付ラベルを返す */

--- a/src/features/shifts/view-utils.ts
+++ b/src/features/shifts/view-utils.ts
@@ -54,23 +54,50 @@ export function weekdayIndex(dateStr: string): number {
   return parseDate(dateStr).getUTCDay();
 }
 
+const MAX_DATE_CACHE_SIZE = 512;
+const holidayCache = new Map<string, boolean>();
+const calendarDayColorCache = new Map<string, 'red' | 'blue' | ''>();
+
 /** YYYY-MM-DD が日本の祝日または振替休日かを判定する。 */
 export function isJapaneseHoliday(dateStr: string): boolean {
+  const cached = holidayCache.get(dateStr);
+  if (cached !== undefined) {
+    return cached;
+  }
+
   const year = Number(dateStr.slice(0, 4));
   const month = Number(dateStr.slice(5, 7));
   const day = Number(dateStr.slice(8, 10));
-  return Boolean(JapaneseHolidays.isHoliday(new Date(year, month - 1, day)));
+  const isHoliday = Boolean(JapaneseHolidays.isHoliday(new Date(year, month - 1, day)));
+  // LRU の更新コストをホットパスに持ち込まず、十分な日数を保持しながらメモリを有界にする。
+  if (holidayCache.size >= MAX_DATE_CACHE_SIZE) {
+    holidayCache.clear();
+  }
+  holidayCache.set(dateStr, isHoliday);
+  return isHoliday;
 }
 
 /** 日本式カレンダーにおける日付文字色を返す（日曜・祝日=赤、土曜=青）。 */
 export function getCalendarDayColor(dateStr: string): 'red' | 'blue' | undefined {
-  if (isJapaneseHoliday(dateStr) || weekdayIndex(dateStr) === 0) {
-    return 'red';
+  const cached = calendarDayColorCache.get(dateStr);
+  if (cached !== undefined) {
+    return cached || undefined;
   }
-  if (weekdayIndex(dateStr) === 6) {
-    return 'blue';
+
+  const dayIndex = weekdayIndex(dateStr);
+  let color: 'red' | 'blue' | '' = '';
+  if (dayIndex === 0 || isJapaneseHoliday(dateStr)) {
+    color = 'red';
+  } else if (dayIndex === 6) {
+    color = 'blue';
   }
-  return undefined;
+
+  // 通常のカレンダー利用では到達しない上限で一括破棄し、キャッシュヒットを Map#get 1回に保つ。
+  if (calendarDayColorCache.size >= MAX_DATE_CACHE_SIZE) {
+    calendarDayColorCache.clear();
+  }
+  calendarDayColorCache.set(dateStr, color);
+  return color || undefined;
 }
 
 /** 「M/D（曜）」形式の短い日付ラベルを返す */

--- a/src/types/japanese-holidays.d.ts
+++ b/src/types/japanese-holidays.d.ts
@@ -1,0 +1,7 @@
+declare module 'japanese-holidays' {
+  const JapaneseHolidays: {
+    isHoliday(date: Date, furikae?: boolean): string | undefined;
+  };
+
+  export default JapaneseHolidays;
+}

--- a/test/japanese-holidays.d.ts
+++ b/test/japanese-holidays.d.ts
@@ -1,7 +1,0 @@
-declare module 'japanese-holidays' {
-  const JapaneseHolidays: {
-    isHoliday(date: Date, furikae?: boolean): string | undefined;
-  };
-
-  export default JapaneseHolidays;
-}

--- a/test/japanese-holidays.d.ts
+++ b/test/japanese-holidays.d.ts
@@ -1,0 +1,7 @@
+declare module 'japanese-holidays' {
+  const JapaneseHolidays: {
+    isHoliday(date: Date, furikae?: boolean): string | undefined;
+  };
+
+  export default JapaneseHolidays;
+}

--- a/test/japanese-holidays.test.ts
+++ b/test/japanese-holidays.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest';
+import JapaneseHolidays from 'japanese-holidays';
+import { describe, expect, it, vi } from 'vitest';
 
 import { getCalendarDayColor, isJapaneseHoliday } from '@/features/shifts/view-utils';
 
@@ -16,5 +17,19 @@ describe('isJapaneseHoliday', () => {
     expect(getCalendarDayColor('2026-02-11')).toBe('red');
     expect(getCalendarDayColor('2026-02-14')).toBe('blue');
     expect(getCalendarDayColor('2026-02-12')).toBeUndefined();
+  });
+
+  it('日曜日は祝日判定を省略し、同じ日付の判定結果を再利用する', () => {
+    const isHolidaySpy = vi.spyOn(JapaneseHolidays, 'isHoliday');
+
+    expect(getCalendarDayColor('2026-03-01')).toBe('red');
+    expect(getCalendarDayColor('2026-03-01')).toBe('red');
+    expect(isHolidaySpy).not.toHaveBeenCalled();
+
+    expect(getCalendarDayColor('2026-03-02')).toBeUndefined();
+    expect(getCalendarDayColor('2026-03-02')).toBeUndefined();
+    expect(isHolidaySpy).toHaveBeenCalledOnce();
+
+    isHolidaySpy.mockRestore();
   });
 });

--- a/test/japanese-holidays.test.ts
+++ b/test/japanese-holidays.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { getCalendarDayColor, isJapaneseHoliday } from '@/features/shifts/view-utils';
+
+describe('isJapaneseHoliday', () => {
+  it('国民の祝日と振替休日を判定する', () => {
+    expect(isJapaneseHoliday('2026-02-11')).toBe(true);
+    expect(isJapaneseHoliday('2026-05-06')).toBe(true);
+  });
+
+  it('祝日ではない平日は判定しない', () => {
+    expect(isJapaneseHoliday('2026-02-12')).toBe(false);
+  });
+
+  it('日曜・祝日は赤、土曜は青を返す', () => {
+    expect(getCalendarDayColor('2026-02-11')).toBe('red');
+    expect(getCalendarDayColor('2026-02-14')).toBe('blue');
+    expect(getCalendarDayColor('2026-02-12')).toBeUndefined();
+  });
+});

--- a/tsconfig.worker.json
+++ b/tsconfig.worker.json
@@ -7,6 +7,7 @@
     "tsBuildInfoFile": "./node_modules/.tmp/worker.tsbuildinfo"
   },
   "include": [
+    "src/types",
     "test",
     "vitest.config.ts",
     "node_modules/@cloudflare/vitest-pool-workers/types/cloudflare-test.d.ts"


### PR DESCRIPTION
## 概要

祝日・振替休日をカレンダー上で赤字表示し、視認性を高める。判定には `japanese-holidays` ライブラリを使用する。

## やったこと

- 祝日・振替休日を判定する `isJapaneseHoliday` を追加
- 日曜・祝日=赤、土曜=青を返す `getCalendarDayColor` を追加
- AvailabilityCalendar・UpcomingShifts・ShiftAgendaViewer・ShiftManager の各カレンダー表示に適用
- 祝日判定・曜日別配色のテストを追加

## レビューポイント

- 配色基準（日曜・祝日=赤、土曜=青）がUI方針として妥当か確認してほしい
