### PR TITLE
✨ Improve shift type setup and instructor ordering

### DIFF
--- a/scripts/seed-dev-data.ts
+++ b/scripts/seed-dev-data.ts
@@ -152,9 +152,13 @@ async function seedCertificationRequirements(
 
     return certificationShortNamesByTier.flatMap((certificationShortNames, tierIndex) =>
       certificationShortNames.map((shortName) => {
-        const certification = certificationRows.find((row) => row.shortName === shortName);
+        const matchedCertifications = certificationRows.filter((row) => row.shortName === shortName);
+        if (matchedCertifications.length !== 1) {
+          throw new Error(`対象資格「${shortName}」を一意に特定できません`);
+        }
+        const [certification] = matchedCertifications;
         if (!certification) {
-          throw new Error('対象資格の作成に失敗しました');
+          throw new Error(`対象資格「${shortName}」を取得できません`);
         }
         return {
           departmentShiftTypeId: frame.id,

--- a/scripts/seed-dev-data.ts
+++ b/scripts/seed-dev-data.ts
@@ -34,11 +34,19 @@ const DEPARTMENT_CODES = { ski: 'ski', snowboard: 'snowboard' } as const;
 // （season.ts 経由）を直接 import できず、値のみここに複製している。
 const SEASON_START_MONTH = 9;
 
-// SKI_CERTIFICATIONS / SNOWBOARD_CERTIFICATIONS の並びに対応する対象資格設定。
+// 資格の shortName に対応する対象資格設定。
 // 外側の配列が資格ランク、内側の配列が同一ランクに属する資格を表す。
-const GENERAL_LESSON_CERTIFICATION_TIERS = [[0], [1], [2]] as const;
-const PREFECTURE_EVENT_CERTIFICATION_TIERS = [[0, 1]] as const;
-const BADGE_TEST_CERTIFICATION_TIERS = [[3, 4, 5]] as const;
+const GENERAL_LESSON_CERTIFICATION_TIERS: readonly (readonly string[])[] = [
+  ['指導員'],
+  ['準指導員'],
+  ['認定指導員'],
+];
+const PREFECTURE_EVENT_CERTIFICATION_TIERS: readonly (readonly string[])[] = [
+  ['指導員', '準指導員'],
+];
+const BADGE_TEST_CERTIFICATION_TIERS: readonly (readonly string[])[] = [
+  ['A級検定員', 'B級検定員', 'C級検定員'],
+];
 
 /** 配列を指定サイズごとのチャンクに分割する（SQLite のバインド変数上限対策） */
 function chunk<T>(items: T[], size: number): T[][] {
@@ -84,7 +92,15 @@ async function seedShiftTypes(db: Db) {
   console.log(
     `シフト種類: ${general.name}, ${group.name}, ${badgeTest.name}, ${prefectureEvent.name}`,
   );
-  console.log('部門別シフト種別設定: スキー4件、スノーボード4件');
+  const skiSettingCount = departmentShiftTypeRows.filter(
+    (row) => row.departmentCode === DEPARTMENT_CODES.ski,
+  ).length;
+  const snowboardSettingCount = departmentShiftTypeRows.filter(
+    (row) => row.departmentCode === DEPARTMENT_CODES.snowboard,
+  ).length;
+  console.log(
+    `部門別シフト種別設定: スキー${skiSettingCount}件、スノーボード${snowboardSettingCount}件`,
+  );
   return { general, group, badgeTest, prefectureEvent, departmentShiftTypeRows };
 }
 
@@ -116,7 +132,10 @@ async function seedCertificationRequirements(
     [DEPARTMENT_CODES.ski]: certs.skiCertifications,
     [DEPARTMENT_CODES.snowboard]: certs.snowboardCertifications,
   };
-  const certificationTierIndicesByShiftTypeId = new Map<string, readonly (readonly number[])[]>([
+  const certificationShortNamesByTierByShiftTypeId = new Map<
+    string,
+    readonly (readonly string[])[]
+  >([
     [shiftTypeRows.general.id, GENERAL_LESSON_CERTIFICATION_TIERS],
     [shiftTypeRows.group.id, []],
     [shiftTypeRows.badgeTest.id, BADGE_TEST_CERTIFICATION_TIERS],
@@ -124,14 +143,16 @@ async function seedCertificationRequirements(
   ]);
   const rows = shiftTypeRows.departmentShiftTypeRows.flatMap((frame) => {
     const certificationRows = certificationRowsByDepartment[frame.departmentCode];
-    const tierIndices = certificationTierIndicesByShiftTypeId.get(frame.shiftTypeId);
-    if (!certificationRows || !tierIndices) {
+    const certificationShortNamesByTier = certificationShortNamesByTierByShiftTypeId.get(
+      frame.shiftTypeId,
+    );
+    if (!certificationRows || !certificationShortNamesByTier) {
       throw new Error('シフト種別設定に対応する対象資格が見つかりません');
     }
 
-    return tierIndices.flatMap((certificationIndices, tierIndex) =>
-      certificationIndices.map((certificationIndex) => {
-        const certification = certificationRows[certificationIndex];
+    return certificationShortNamesByTier.flatMap((certificationShortNames, tierIndex) =>
+      certificationShortNames.map((shortName) => {
+        const certification = certificationRows.find((row) => row.shortName === shortName);
         if (!certification) {
           throw new Error('対象資格の作成に失敗しました');
         }
@@ -199,7 +220,7 @@ async function seedInstructors(db: Db) {
   return created;
 }
 
-type CertRow = { id: string };
+type CertRow = { id: string; shortName: string };
 
 // 資格パターン定義（インデックスは SKI_CERTIFICATIONS / SNOWBOARD_CERTIFICATIONS の並びに対応）
 // [0]公認指導員, [1]準指導員, [2]認定指導員, [3]A級検定員, [4]B級検定員, [5]C級検定員

--- a/scripts/seed-dev-data.ts
+++ b/scripts/seed-dev-data.ts
@@ -14,6 +14,7 @@ import { drizzle } from 'drizzle-orm/libsql';
 import JapaneseHolidays from 'japanese-holidays';
 
 import {
+  certificationRequirements,
   certifications,
   departmentShiftTypes,
   instructorAvailabilities,
@@ -32,6 +33,12 @@ const DEPARTMENT_CODES = { ski: 'ski', snowboard: 'snowboard' } as const;
 // このスクリプトは `node` で直接実行するため、拡張子省略の内部 import を含む src 側モジュール
 // （season.ts 経由）を直接 import できず、値のみここに複製している。
 const SEASON_START_MONTH = 9;
+
+// SKI_CERTIFICATIONS / SNOWBOARD_CERTIFICATIONS の並びに対応する対象資格設定。
+// 外側の配列が資格ランク、内側の配列が同一ランクに属する資格を表す。
+const GENERAL_LESSON_CERTIFICATION_TIERS = [[0], [1], [2]] as const;
+const PREFECTURE_EVENT_CERTIFICATION_TIERS = [[0, 1]] as const;
+const BADGE_TEST_CERTIFICATION_TIERS = [[3, 4, 5]] as const;
 
 /** 配列を指定サイズごとのチャンクに分割する（SQLite のバインド変数上限対策） */
 function chunk<T>(items: T[], size: number): T[][] {
@@ -61,21 +68,24 @@ async function seedShiftTypes(db: Db) {
   }
 
   const shiftTypeRows = [general, group, badgeTest, prefectureEvent];
-  await db.insert(departmentShiftTypes).values(
-    Object.values(DEPARTMENT_CODES).flatMap((departmentCode) =>
-      shiftTypeRows.map((shiftType, index) => ({
-        departmentCode,
-        shiftTypeId: shiftType.id,
-        sortOrder: index + 1,
-      })),
-    ),
-  );
+  const departmentShiftTypeRows = await db
+    .insert(departmentShiftTypes)
+    .values(
+      Object.values(DEPARTMENT_CODES).flatMap((departmentCode) =>
+        shiftTypeRows.map((shiftType, index) => ({
+          departmentCode,
+          shiftTypeId: shiftType.id,
+          sortOrder: index + 1,
+        })),
+      ),
+    )
+    .returning();
 
   console.log(
     `シフト種類: ${general.name}, ${group.name}, ${badgeTest.name}, ${prefectureEvent.name}`,
   );
   console.log('部門別シフト種別設定: スキー4件、スノーボード4件');
-  return { general, group, badgeTest, prefectureEvent };
+  return { general, group, badgeTest, prefectureEvent, departmentShiftTypeRows };
 }
 
 const SKI_CERTIFICATIONS = [
@@ -95,6 +105,48 @@ const SNOWBOARD_CERTIFICATIONS = [
   { name: '公認スノーボードB級検定員', shortName: 'B級検定員', organization: 'SAJ' },
   { name: '公認スノーボードC級検定員', shortName: 'C級検定員', organization: 'SAJ' },
 ];
+
+/** 部門別シフト種別ごとの対象資格を、資格レベル順に投入する */
+async function seedCertificationRequirements(
+  db: Db,
+  shiftTypeRows: Awaited<ReturnType<typeof seedShiftTypes>>,
+  certs: { skiCertifications: CertRow[]; snowboardCertifications: CertRow[] },
+) {
+  const certificationRowsByDepartment = {
+    [DEPARTMENT_CODES.ski]: certs.skiCertifications,
+    [DEPARTMENT_CODES.snowboard]: certs.snowboardCertifications,
+  };
+  const certificationTierIndicesByShiftTypeId = new Map<string, readonly (readonly number[])[]>([
+    [shiftTypeRows.general.id, GENERAL_LESSON_CERTIFICATION_TIERS],
+    [shiftTypeRows.group.id, []],
+    [shiftTypeRows.badgeTest.id, BADGE_TEST_CERTIFICATION_TIERS],
+    [shiftTypeRows.prefectureEvent.id, PREFECTURE_EVENT_CERTIFICATION_TIERS],
+  ]);
+  const rows = shiftTypeRows.departmentShiftTypeRows.flatMap((frame) => {
+    const certificationRows = certificationRowsByDepartment[frame.departmentCode];
+    const tierIndices = certificationTierIndicesByShiftTypeId.get(frame.shiftTypeId);
+    if (!certificationRows || !tierIndices) {
+      throw new Error('シフト種別設定に対応する対象資格が見つかりません');
+    }
+
+    return tierIndices.flatMap((certificationIndices, tierIndex) =>
+      certificationIndices.map((certificationIndex) => {
+        const certification = certificationRows[certificationIndex];
+        if (!certification) {
+          throw new Error('対象資格の作成に失敗しました');
+        }
+        return {
+          departmentShiftTypeId: frame.id,
+          certificationId: certification.id,
+          tierRank: tierIndex + 1,
+        };
+      }),
+    );
+  });
+
+  await db.insert(certificationRequirements).values(rows);
+  console.log(`対象資格設定: ${rows.length}件作成`);
+}
 
 /** 資格データ（部門ごとに6件ずつ）を投入する */
 async function seedCertifications(db: Db) {
@@ -677,6 +729,7 @@ async function clearExistingData(db: Db) {
   await db.delete(instructorAvailabilities);
   await db.delete(shiftAssignments);
   await db.delete(shifts);
+  await db.delete(certificationRequirements);
   await db.delete(instructorCertifications);
   await db.delete(instructors);
   await db.delete(certifications);
@@ -703,6 +756,7 @@ async function main() {
     };
 
     const certs = await seedCertifications(db);
+    await seedCertificationRequirements(db, shiftTypeRows, certs);
     const instructorRows = await seedInstructors(db);
     const instructorCertRows = await seedInstructorCertifications(db, instructorRows, certs);
 

--- a/scripts/seed-dev-data.ts
+++ b/scripts/seed-dev-data.ts
@@ -15,6 +15,7 @@ import JapaneseHolidays from 'japanese-holidays';
 
 import {
   certifications,
+  departmentShiftTypes,
   instructorAvailabilities,
   instructorCertifications,
   instructors,
@@ -43,7 +44,7 @@ function chunk<T>(items: T[], size: number): T[][] {
 
 type Db = ReturnType<typeof drizzle>;
 
-/** シフト種類データ（一般レッスン・団体レッスン・バッジテスト・県連事業）を投入する */
+/** シフト種類と部門別の利用設定を投入する */
 async function seedShiftTypes(db: Db) {
   const [general, group, badgeTest, prefectureEvent] = await db
     .insert(shiftTypes)
@@ -59,9 +60,21 @@ async function seedShiftTypes(db: Db) {
     throw new Error('シフト種類データの作成に失敗しました');
   }
 
+  const shiftTypeRows = [general, group, badgeTest, prefectureEvent];
+  await db.insert(departmentShiftTypes).values(
+    Object.values(DEPARTMENT_CODES).flatMap((departmentCode) =>
+      shiftTypeRows.map((shiftType, index) => ({
+        departmentCode,
+        shiftTypeId: shiftType.id,
+        sortOrder: index + 1,
+      })),
+    ),
+  );
+
   console.log(
     `シフト種類: ${general.name}, ${group.name}, ${badgeTest.name}, ${prefectureEvent.name}`,
   );
+  console.log('部門別シフト種別設定: スキー4件、スノーボード4件');
   return { general, group, badgeTest, prefectureEvent };
 }
 
@@ -667,6 +680,7 @@ async function clearExistingData(db: Db) {
   await db.delete(instructorCertifications);
   await db.delete(instructors);
   await db.delete(certifications);
+  await db.delete(departmentShiftTypes);
   await db.delete(shiftTypes);
   console.log('既存データのクリア完了\n');
 }

--- a/src/features/department-shift-types/api.ts
+++ b/src/features/department-shift-types/api.ts
@@ -1,4 +1,5 @@
 import { and, asc, eq, inArray, max } from 'drizzle-orm';
+import type { BatchItem } from 'drizzle-orm/batch';
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import { validator } from 'hono/validator';
@@ -174,17 +175,58 @@ export const departmentShiftTypesRoute = new Hono<{
         }
       }
 
-      const removeCurrent = db
-        .delete(departmentShiftTypes)
+      // 継続する行の ID を保ち、資格要件の cascade 削除を避けるため、
+      // 削除・追加・順序変更を差分として単一バッチにまとめる。
+      const currentAssignments = await db
+        .select({
+          id: departmentShiftTypes.id,
+          shiftTypeId: departmentShiftTypes.shiftTypeId,
+          sortOrder: departmentShiftTypes.sortOrder,
+        })
+        .from(departmentShiftTypes)
         .where(eq(departmentShiftTypes.departmentCode, departmentCode));
-      const additions = shiftTypeIds.map((shiftTypeId, index) =>
-        db.insert(departmentShiftTypes).values({
-          departmentCode,
-          shiftTypeId,
-          sortOrder: index + 1,
-        }),
+      const assignmentByShiftTypeId = new Map(
+        currentAssignments.map((assignment) => [assignment.shiftTypeId, assignment]),
       );
-      await db.batch([removeCurrent, ...additions]);
+      const requestedShiftTypeIds = new Set(shiftTypeIds);
+      const removedAssignmentIds = currentAssignments
+        .filter((assignment) => !requestedShiftTypeIds.has(assignment.shiftTypeId))
+        .map((assignment) => assignment.id);
+      const assignmentChanges: BatchItem<'sqlite'>[] = [];
+      if (removedAssignmentIds.length > 0) {
+        assignmentChanges.push(
+          db
+            .delete(departmentShiftTypes)
+            .where(inArray(departmentShiftTypes.id, removedAssignmentIds)),
+        );
+      }
+      for (const [index, shiftTypeId] of shiftTypeIds.entries()) {
+        const current = assignmentByShiftTypeId.get(shiftTypeId);
+        const sortOrder = index + 1;
+        if (!current) {
+          assignmentChanges.push(
+            db.insert(departmentShiftTypes).values({
+              departmentCode,
+              shiftTypeId,
+              sortOrder,
+            }),
+          );
+          continue;
+        }
+        if (current.sortOrder === sortOrder) {
+          continue;
+        }
+        assignmentChanges.push(
+          db
+            .update(departmentShiftTypes)
+            .set({ sortOrder })
+            .where(eq(departmentShiftTypes.id, current.id)),
+        );
+      }
+      const [firstChange, ...remainingChanges] = assignmentChanges;
+      if (firstChange) {
+        await db.batch([firstChange, ...remainingChanges]);
+      }
 
       const rows = await selectDepartmentShiftTypes(db, departmentCode);
 

--- a/src/features/department-shift-types/api.ts
+++ b/src/features/department-shift-types/api.ts
@@ -174,21 +174,6 @@ export const departmentShiftTypesRoute = new Hono<{
         }
       }
 
-      const currentAssignments = await db
-        .select({ shiftTypeId: departmentShiftTypes.shiftTypeId })
-        .from(departmentShiftTypes)
-        .where(eq(departmentShiftTypes.departmentCode, departmentCode));
-      const currentShiftTypeIds = new Set(
-        currentAssignments.map((assignment) => assignment.shiftTypeId),
-      );
-      // 一括更新は並べ替え専用とし、割当集合の変更は個別の追加・除外APIへ委ねる
-      if (
-        currentShiftTypeIds.size !== shiftTypeIds.length ||
-        shiftTypeIds.some((shiftTypeId) => !currentShiftTypeIds.has(shiftTypeId))
-      ) {
-        throw new HTTPException(400, { message: 'Shift type IDs must match current assignments' });
-      }
-
       const removeCurrent = db
         .delete(departmentShiftTypes)
         .where(eq(departmentShiftTypes.departmentCode, departmentCode));

--- a/src/features/department-shift-types/components/CreateDepartmentShiftTypeDialog.tsx
+++ b/src/features/department-shift-types/components/CreateDepartmentShiftTypeDialog.tsx
@@ -1,0 +1,74 @@
+import { Group, Modal, Stack } from '@mantine/core';
+import { notifications } from '@mantine/notifications';
+
+import { ErrorAlert } from '@/components/AppAlert';
+import { AppButton } from '@/components/AppButton';
+import { DEPARTMENT_LABELS, type DepartmentCode } from '@/features/departments/schema';
+import { ShiftTypeFormFields } from '@/features/shift-types/components/ShiftTypeForm';
+import {
+  useShiftTypeForm,
+  type ShiftTypeFormValues,
+} from '@/features/shift-types/components/useShiftTypeForm';
+
+import { useCreateDepartmentShiftType } from '../queries';
+
+/**
+ * シフト種別マスタを登録し、指定部門へ続けて割り当てる入力Dialog。
+ * 登録後の種別IDを親へ渡し、必要資格の編集対象へすぐ切り替えられるようにする。
+ */
+export function CreateDepartmentShiftTypeDialog({
+  opened,
+  departmentCode,
+  onClose,
+  onCreated,
+}: {
+  opened: boolean;
+  departmentCode: DepartmentCode;
+  onClose: () => void;
+  onCreated: (shiftTypeId: string) => void;
+}) {
+  const form = useShiftTypeForm();
+  const create = useCreateDepartmentShiftType(departmentCode);
+
+  const close = () => {
+    if (create.isPending) return;
+    form.reset();
+    onClose();
+  };
+
+  const handleSubmit = async (values: ShiftTypeFormValues) => {
+    try {
+      const createdShiftTypes = await create.mutateAsync({ name: values.name });
+      const created = createdShiftTypes.at(-1);
+      if (!created) throw new Error('登録したシフト種別を取得できませんでした');
+
+      notifications.show({
+        color: 'green',
+        message: `${created.name}を登録し、${DEPARTMENT_LABELS[departmentCode]}部門に追加しました`,
+      });
+      form.reset();
+      onCreated(created.shiftTypeId);
+    } catch {
+      // エラーはDialog内で表示するため、ここでは状態更新のみを行う。
+    }
+  };
+
+  return (
+    <Modal opened={opened} onClose={close} title="シフト種別を登録して追加" centered>
+      <form onSubmit={form.onSubmit(handleSubmit)}>
+        <Stack gap="lg">
+          <ShiftTypeFormFields form={form} />
+          {create.isError && <ErrorAlert>{create.error.message}</ErrorAlert>}
+          <Group justify="flex-end">
+            <AppButton intent="secondary" type="button" onClick={close} disabled={create.isPending}>
+              キャンセル
+            </AppButton>
+            <AppButton intent="primary" type="submit" loading={create.isPending}>
+              登録して{DEPARTMENT_LABELS[departmentCode]}部門に追加
+            </AppButton>
+          </Group>
+        </Stack>
+      </form>
+    </Modal>
+  );
+}

--- a/src/features/department-shift-types/components/DepartmentShiftTypeCatalog.tsx
+++ b/src/features/department-shift-types/components/DepartmentShiftTypeCatalog.tsx
@@ -1,71 +1,10 @@
-import { ActionIcon, Stack } from '@mantine/core';
-import { notifications } from '@mantine/notifications';
-import { IconArrowLeft } from '@tabler/icons-react';
+import { ShiftTypeList, type ShiftTypeDrawerState } from '@/features/shift-types';
 
-import { ErrorAlert } from '@/components/AppAlert';
-import { DEPARTMENT_LABELS, type DepartmentCode } from '@/features/departments/schema';
-import {
-  ShiftTypeList,
-  type ShiftTypeDrawerState,
-  type ShiftTypeListItem,
-} from '@/features/shift-types';
-
-import { useAssignDepartmentShiftType, useDepartmentShiftTypes } from '../queries';
-
-/** 共有シフト種別マスタから、指定部門で利用する種別を選ぶパネル。 */
+/** 共有シフト種別マスタを表示し、登録・編集フォームを開くパネル。 */
 export function DepartmentShiftTypeCatalog({
-  departmentCode,
   onOpenForm,
 }: {
-  departmentCode: DepartmentCode;
   onOpenForm?: (state: ShiftTypeDrawerState) => void;
 }) {
-  const { data: departmentShiftTypes } = useDepartmentShiftTypes(departmentCode);
-  const assign = useAssignDepartmentShiftType(departmentCode);
-  const assignedShiftTypeIds = new Set(
-    (departmentShiftTypes ?? []).map((shiftType) => shiftType.shiftTypeId),
-  );
-
-  const assignShiftType = (shiftType: ShiftTypeListItem) => {
-    if (!departmentShiftTypes || assignedShiftTypeIds.has(shiftType.id)) return;
-    assign.mutate(shiftType.id, {
-      onSuccess: () => {
-        notifications.show({
-          color: 'green',
-          message: `${shiftType.name}を${DEPARTMENT_LABELS[departmentCode]}部門で利用できるようにしました`,
-        });
-      },
-    });
-  };
-
-  return (
-    <Stack gap="md">
-      <ShiftTypeList
-        {...(onOpenForm ? { onOpenForm } : {})}
-        rowActionHeader=""
-        renderRowAction={(shiftType) => {
-          const isAssigned = assignedShiftTypeIds.has(shiftType.id);
-          const isDisabled = isAssigned || !shiftType.isActive;
-          return (
-            <ActionIcon
-              aria-label={
-                isAssigned
-                  ? `${shiftType.name}は${DEPARTMENT_LABELS[departmentCode]}部門で利用中`
-                  : !shiftType.isActive
-                    ? `${shiftType.name}は無効のため追加できません`
-                    : `${shiftType.name}を${DEPARTMENT_LABELS[departmentCode]}部門で利用する`
-              }
-              variant="subtle"
-              disabled={isDisabled || !departmentShiftTypes || assign.isPending}
-              loading={assign.isPending}
-              onClick={() => assignShiftType(shiftType)}
-            >
-              <IconArrowLeft size={16} />
-            </ActionIcon>
-          );
-        }}
-      />
-      {assign.isError && <ErrorAlert>{assign.error.message}</ErrorAlert>}
-    </Stack>
-  );
+  return <ShiftTypeList {...(onOpenForm ? { onOpenForm } : {})} />;
 }

--- a/src/features/department-shift-types/components/DepartmentShiftTypeList.tsx
+++ b/src/features/department-shift-types/components/DepartmentShiftTypeList.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useMemo, useState } from 'react';
+
 import { ActionIcon, Divider, Group, Paper, Select, Stack, Text } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import { IconArrowDown, IconArrowUp, IconListDetails, IconTrash } from '@tabler/icons-react';
@@ -5,15 +7,11 @@ import { IconArrowDown, IconArrowUp, IconListDetails, IconTrash } from '@tabler/
 import { ErrorAlert } from '@/components/AppAlert';
 import { AppBadge } from '@/components/AppBadge';
 import { ListEmptyState } from '@/components/ListEmptyState';
+import { UnsavedChangesBar } from '@/components/UnsavedChangesBar';
 import { DEPARTMENT_LABELS, type DepartmentCode } from '@/features/departments/schema';
 import { useShiftTypes } from '@/features/shift-types/queries';
 
-import {
-  useAssignDepartmentShiftType,
-  useDepartmentShiftTypes,
-  useRemoveDepartmentShiftType,
-  useUpdateDepartmentShiftTypes,
-} from '../queries';
+import { useDepartmentShiftTypes, useUpdateDepartmentShiftTypes } from '../queries';
 import type { DepartmentShiftType } from '../schema';
 
 /** 部門ごとの利用可能なシフト種別を追加・除外・並べ替えする一覧。 */
@@ -22,15 +20,17 @@ export function DepartmentShiftTypeList({
   selectedShiftTypeId,
   onSelect,
   canAssign,
-  onAssigned,
   canRemove,
+  onRemoved,
+  onDirtyChange,
 }: {
   departmentCode: DepartmentCode;
   selectedShiftTypeId?: string | null;
   onSelect?: (shiftTypeId: string) => void;
   canAssign?: () => boolean;
-  onAssigned?: (shiftTypeId: string, assignedDepartmentCode: DepartmentCode) => void;
   canRemove?: (shiftTypeId: string) => boolean;
+  onRemoved?: (nextSelectedShiftTypeId: string | null) => void;
+  onDirtyChange?: (dirty: boolean) => void;
 }) {
   const {
     data: departmentShiftTypes,
@@ -43,27 +43,40 @@ export function DepartmentShiftTypeList({
     isError: isShiftTypesError,
   } = useShiftTypes();
   const update = useUpdateDepartmentShiftTypes(departmentCode);
-  const assignMutation = useAssignDepartmentShiftType(departmentCode);
-  const removeMutation = useRemoveDepartmentShiftType(departmentCode);
-  const items = departmentShiftTypes ?? [];
+  const [stagedItems, setStagedItems] = useState<DepartmentShiftType[] | null>(null);
+  const items = stagedItems ?? departmentShiftTypes ?? [];
   const assignedShiftTypeIds = new Set(items.map((item) => item.shiftTypeId));
   const shiftTypesToAssign = (shiftTypes ?? []).filter(
     (shiftType) => !assignedShiftTypeIds.has(shiftType.id),
   );
 
-  const save = (shiftTypeIds: string[], message: string) => {
-    update.mutate(
-      { shiftTypeIds },
-      {
-        onSuccess: () => notifications.show({ color: 'green', message }),
-      },
-    );
+  const isDirty = useMemo(() => {
+    if (!stagedItems || !departmentShiftTypes) return false;
+    return !hasSameShiftTypeOrder(stagedItems, departmentShiftTypes);
+  }, [departmentShiftTypes, stagedItems]);
+
+  useEffect(() => {
+    onDirtyChange?.(isDirty);
+  }, [isDirty, onDirtyChange]);
+
+  const stage = (nextItems: DepartmentShiftType[]) => {
+    if (departmentShiftTypes && hasSameShiftTypeOrder(nextItems, departmentShiftTypes)) {
+      setStagedItems(null);
+      return;
+    }
+    setStagedItems(nextItems);
   };
 
-  const remove = (shiftTypeId: string, name: string) => {
-    removeMutation.mutate(shiftTypeId, {
-      onSuccess: () => notifications.show({ color: 'green', message: `${name}を除外しました` }),
-    });
+  const save = () => {
+    update.mutate(
+      { shiftTypeIds: items.map((item) => item.shiftTypeId) },
+      {
+        onSuccess: () => {
+          setStagedItems(null);
+          notifications.show({ color: 'green', message: 'シフト種別の利用設定を保存しました' });
+        },
+      },
+    );
   };
 
   const assign = (shiftTypeId: string | null) => {
@@ -72,15 +85,15 @@ export function DepartmentShiftTypeList({
     const shiftType = shiftTypesToAssign.find((item) => item.id === shiftTypeId);
     if (!shiftType) return;
 
-    assignMutation.mutate(shiftTypeId, {
-      onSuccess: () => {
-        notifications.show({
-          color: 'green',
-          message: `${shiftType.name}を${DEPARTMENT_LABELS[departmentCode]}部門に追加しました`,
-        });
-        onAssigned?.(shiftTypeId, departmentCode);
+    stage([
+      ...items,
+      {
+        shiftTypeId: shiftType.id,
+        name: shiftType.name,
+        isActive: shiftType.isActive,
+        sortOrder: items.length + 1,
       },
-    });
+    ]);
   };
 
   const move = (shiftTypeId: string, offset: -1 | 1) => {
@@ -92,10 +105,15 @@ export function DepartmentShiftTypeList({
     const [source] = reordered.splice(sourceIndex, 1);
     if (!source) return;
     reordered.splice(targetIndex, 0, source);
-    save(
-      reordered.map((item) => item.shiftTypeId),
-      '並び順を更新しました',
-    );
+    stage(reordered);
+  };
+
+  const remove = (shiftTypeId: string) => {
+    const nextItems = items.filter((item) => item.shiftTypeId !== shiftTypeId);
+    stage(nextItems);
+    if (selectedShiftTypeId === shiftTypeId) {
+      onRemoved?.(nextItems[0]?.shiftTypeId ?? null);
+    }
   };
 
   return (
@@ -117,9 +135,7 @@ export function DepartmentShiftTypeList({
           label: shiftType.name,
         }))}
         nothingFoundMessage="追加できるシフト種別がありません"
-        disabled={
-          isShiftTypesLoading || assignMutation.isPending || shiftTypesToAssign.length === 0
-        }
+        disabled={isShiftTypesLoading || update.isPending || shiftTypesToAssign.length === 0}
         onChange={assign}
       />
       <Divider />
@@ -146,10 +162,10 @@ export function DepartmentShiftTypeList({
             <ShiftTypeRow
               key={item.shiftTypeId}
               item={item}
-              isUpdating={update.isPending || removeMutation.isPending}
+              isUpdating={update.isPending}
               onRemove={() => {
                 if (canRemove?.(item.shiftTypeId) === false) return;
-                remove(item.shiftTypeId, item.name);
+                remove(item.shiftTypeId);
               }}
               selected={selectedShiftTypeId === item.shiftTypeId}
               onSelect={() => onSelect?.(item.shiftTypeId)}
@@ -164,9 +180,25 @@ export function DepartmentShiftTypeList({
 
       {update.isError && <ErrorAlert>{update.error.message}</ErrorAlert>}
       {isShiftTypesError && <ErrorAlert>シフト種別マスタの取得に失敗しました</ErrorAlert>}
-      {assignMutation.isError && <ErrorAlert>{assignMutation.error.message}</ErrorAlert>}
-      {removeMutation.isError && <ErrorAlert>{removeMutation.error.message}</ErrorAlert>}
+      {isDirty && (
+        <UnsavedChangesBar
+          description="この部門で利用するシフト種別と表示順をまとめて保存します"
+          loading={update.isPending}
+          onCancel={() => setStagedItems(null)}
+          onSave={save}
+        />
+      )}
     </Stack>
+  );
+}
+
+function hasSameShiftTypeOrder(
+  first: DepartmentShiftType[],
+  second: DepartmentShiftType[],
+): boolean {
+  return (
+    first.length === second.length &&
+    first.every((item, index) => item.shiftTypeId === second[index]?.shiftTypeId)
   );
 }
 
@@ -182,7 +214,7 @@ type ShiftTypeRowProps = {
   onMoveDown: () => void;
 };
 
-/** 上下移動と即時除外を提供する部門別シフト種別の1行。 */
+/** 上下移動とステージへの除外を提供する部門別シフト種別の1行。 */
 function ShiftTypeRow({
   item,
   isUpdating,

--- a/src/features/department-shift-types/components/DepartmentShiftTypeList.tsx
+++ b/src/features/department-shift-types/components/DepartmentShiftTypeList.tsx
@@ -1,20 +1,15 @@
-import { ActionIcon, Group, Paper, Stack, Text } from '@mantine/core';
+import { ActionIcon, Divider, Group, Paper, Select, Stack, Text } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
-import {
-  IconArrowDown,
-  IconArrowUp,
-  IconListDetails,
-  IconPlus,
-  IconTrash,
-} from '@tabler/icons-react';
+import { IconArrowDown, IconArrowUp, IconListDetails, IconTrash } from '@tabler/icons-react';
 
 import { ErrorAlert } from '@/components/AppAlert';
 import { AppBadge } from '@/components/AppBadge';
-import { AppButton } from '@/components/AppButton';
 import { ListEmptyState } from '@/components/ListEmptyState';
 import { DEPARTMENT_LABELS, type DepartmentCode } from '@/features/departments/schema';
+import { useShiftTypes } from '@/features/shift-types/queries';
 
 import {
+  useAssignDepartmentShiftType,
   useDepartmentShiftTypes,
   useRemoveDepartmentShiftType,
   useUpdateDepartmentShiftTypes,
@@ -26,13 +21,15 @@ export function DepartmentShiftTypeList({
   departmentCode,
   selectedShiftTypeId,
   onSelect,
-  onAdd,
+  canAssign,
+  onAssigned,
   canRemove,
 }: {
   departmentCode: DepartmentCode;
   selectedShiftTypeId?: string | null;
   onSelect?: (shiftTypeId: string) => void;
-  onAdd?: () => void;
+  canAssign?: () => boolean;
+  onAssigned?: (shiftTypeId: string, assignedDepartmentCode: DepartmentCode) => void;
   canRemove?: (shiftTypeId: string) => boolean;
 }) {
   const {
@@ -40,9 +37,19 @@ export function DepartmentShiftTypeList({
     isLoading,
     isError,
   } = useDepartmentShiftTypes(departmentCode);
+  const {
+    data: shiftTypes,
+    isLoading: isShiftTypesLoading,
+    isError: isShiftTypesError,
+  } = useShiftTypes();
   const update = useUpdateDepartmentShiftTypes(departmentCode);
+  const assignMutation = useAssignDepartmentShiftType(departmentCode);
   const removeMutation = useRemoveDepartmentShiftType(departmentCode);
   const items = departmentShiftTypes ?? [];
+  const assignedShiftTypeIds = new Set(items.map((item) => item.shiftTypeId));
+  const shiftTypesToAssign = (shiftTypes ?? []).filter(
+    (shiftType) => !assignedShiftTypeIds.has(shiftType.id),
+  );
 
   const save = (shiftTypeIds: string[], message: string) => {
     update.mutate(
@@ -56,6 +63,23 @@ export function DepartmentShiftTypeList({
   const remove = (shiftTypeId: string, name: string) => {
     removeMutation.mutate(shiftTypeId, {
       onSuccess: () => notifications.show({ color: 'green', message: `${name}を除外しました` }),
+    });
+  };
+
+  const assign = (shiftTypeId: string | null) => {
+    if (!shiftTypeId || canAssign?.() === false) return;
+
+    const shiftType = shiftTypesToAssign.find((item) => item.id === shiftTypeId);
+    if (!shiftType) return;
+
+    assignMutation.mutate(shiftTypeId, {
+      onSuccess: () => {
+        notifications.show({
+          color: 'green',
+          message: `${shiftType.name}を${DEPARTMENT_LABELS[departmentCode]}部門に追加しました`,
+        });
+        onAssigned?.(shiftTypeId, departmentCode);
+      },
     });
   };
 
@@ -83,6 +107,23 @@ export function DepartmentShiftTypeList({
         </Text>
       </Stack>
 
+      <Select
+        label="シフト種別を追加"
+        placeholder="シフト種別を選択"
+        searchable
+        value={null}
+        data={shiftTypesToAssign.map((shiftType) => ({
+          value: shiftType.id,
+          label: shiftType.name,
+        }))}
+        nothingFoundMessage="追加できるシフト種別がありません"
+        disabled={
+          isShiftTypesLoading || assignMutation.isPending || shiftTypesToAssign.length === 0
+        }
+        onChange={assign}
+      />
+      <Divider />
+
       {isError && <ErrorAlert>部門別シフト種別の取得に失敗しました</ErrorAlert>}
 
       {isLoading && (
@@ -95,7 +136,7 @@ export function DepartmentShiftTypeList({
         <ListEmptyState
           icon={<IconListDetails size={32} stroke={1.5} />}
           title="シフト種別がありません"
-          description="マスタ一覧の ← から、この部門で利用する種別を追加してください。"
+          description="上のセレクトから、この部門で利用する種別を追加してください。"
         />
       )}
 
@@ -121,13 +162,9 @@ export function DepartmentShiftTypeList({
         </Stack>
       )}
 
-      {onAdd && (
-        <AppButton intent="tertiary" leftSection={<IconPlus size={16} />} onClick={onAdd}>
-          シフト種別を追加
-        </AppButton>
-      )}
-
       {update.isError && <ErrorAlert>{update.error.message}</ErrorAlert>}
+      {isShiftTypesError && <ErrorAlert>シフト種別マスタの取得に失敗しました</ErrorAlert>}
+      {assignMutation.isError && <ErrorAlert>{assignMutation.error.message}</ErrorAlert>}
       {removeMutation.isError && <ErrorAlert>{removeMutation.error.message}</ErrorAlert>}
     </Stack>
   );

--- a/src/features/department-shift-types/index.ts
+++ b/src/features/department-shift-types/index.ts
@@ -1,3 +1,4 @@
 export { DepartmentShiftTypeCatalog } from './components/DepartmentShiftTypeCatalog';
+export { CreateDepartmentShiftTypeDialog } from './components/CreateDepartmentShiftTypeDialog';
 export { DepartmentShiftTypeList } from './components/DepartmentShiftTypeList';
 export { useDepartmentShiftTypes } from './queries';

--- a/src/features/shift-types/components/EditShiftTypeDialog.tsx
+++ b/src/features/shift-types/components/EditShiftTypeDialog.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+
+import { Modal } from '@mantine/core';
+
+import { ShiftTypeEditForm } from './ShiftTypeDrawer';
+
+/** シフト種別マスタの編集を登録時と同じモーダルで提供する。 */
+export function EditShiftTypeDialog({
+  opened,
+  shiftTypeId,
+  onClose,
+}: {
+  opened: boolean;
+  shiftTypeId: string | null;
+  onClose: () => void;
+}) {
+  const [saving, setSaving] = useState(false);
+
+  const close = () => {
+    if (!saving) onClose();
+  };
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={close}
+      title="シフト種別を編集"
+      centered
+      closeOnClickOutside={!saving}
+      closeOnEscape={!saving}
+      withCloseButton={!saving}
+    >
+      {shiftTypeId && (
+        <ShiftTypeEditForm
+          key={shiftTypeId}
+          shiftTypeId={shiftTypeId}
+          onClose={onClose}
+          onSavingChange={setSaving}
+        />
+      )}
+    </Modal>
+  );
+}

--- a/src/features/shift-types/components/ShiftTypeDrawer.tsx
+++ b/src/features/shift-types/components/ShiftTypeDrawer.tsx
@@ -41,7 +41,7 @@ export function ShiftTypeDrawer({ state, onClose }: Props) {
       title={isEdit ? 'シフト種別を編集' : 'シフト種別を新規登録'}
     >
       {effectiveState?.mode === 'edit' ? (
-        <EditPanel
+        <ShiftTypeEditForm
           key={effectiveState.shiftTypeId}
           shiftTypeId={effectiveState.shiftTypeId}
           onClose={onClose}
@@ -62,7 +62,7 @@ export function ShiftTypeDrawerContent({
   onDone: () => void;
 }) {
   return state.mode === 'edit' ? (
-    <EditPanel shiftTypeId={state.shiftTypeId} onClose={onDone} />
+    <ShiftTypeEditForm shiftTypeId={state.shiftTypeId} onClose={onDone} />
   ) : (
     <CreatePanel onClose={onDone} />
   );
@@ -107,7 +107,15 @@ function CreatePanel({ onClose }: { onClose: () => void }) {
 }
 
 /** 編集対象の詳細を読み込み、揃うまで Skeleton を表示するローダー */
-function EditPanel({ shiftTypeId, onClose }: { shiftTypeId: string; onClose: () => void }) {
+export function ShiftTypeEditForm({
+  shiftTypeId,
+  onClose,
+  onSavingChange,
+}: {
+  shiftTypeId: string;
+  onClose: () => void;
+  onSavingChange?: (saving: boolean) => void;
+}) {
   const { data: detail, isLoading } = useShiftType(shiftTypeId);
   const { data: shiftTypes } = useShiftTypes(false);
 
@@ -129,6 +137,7 @@ function EditPanel({ shiftTypeId, onClose }: { shiftTypeId: string; onClose: () 
       detail={detail}
       availableDepartmentCount={availableDepartmentCount}
       onClose={onClose}
+      {...(onSavingChange ? { onSavingChange } : {})}
     />
   );
 }
@@ -137,6 +146,7 @@ type EditFormProps = {
   detail: ShiftType;
   availableDepartmentCount: number | undefined;
   onClose: () => void;
+  onSavingChange?: (saving: boolean) => void;
 };
 
 /**
@@ -144,7 +154,7 @@ type EditFormProps = {
  * 保存で初期値との差分だけをまとめて API に反映する。
  * 有効・無効の切り替えは可逆であり、無効化による影響は保存前に表示する。
  */
-function EditForm({ detail, availableDepartmentCount, onClose }: EditFormProps) {
+function EditForm({ detail, availableDepartmentCount, onClose, onSavingChange }: EditFormProps) {
   const form = useShiftTypeForm({ name: detail.name });
   const [active, setActive] = useState(detail.isActive);
   const [saving, setSaving] = useState(false);
@@ -154,6 +164,7 @@ function EditForm({ detail, availableDepartmentCount, onClose }: EditFormProps) 
 
   const handleSave = async (values: ShiftTypeFormValues) => {
     setSaving(true);
+    onSavingChange?.(true);
     setError(null);
     try {
       if (values.name !== detail.name || active !== detail.isActive) {
@@ -168,6 +179,7 @@ function EditForm({ detail, availableDepartmentCount, onClose }: EditFormProps) 
       setError(e instanceof Error ? e.message : 'シフト種別の保存に失敗しました');
     } finally {
       setSaving(false);
+      onSavingChange?.(false);
     }
   };
 

--- a/src/features/shift-types/components/ShiftTypeSettings.tsx
+++ b/src/features/shift-types/components/ShiftTypeSettings.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { Drawer, Grid, Group, Modal, Paper, Stack, Tabs, Text } from '@mantine/core';
 import { IconArrowLeft, IconDatabase } from '@tabler/icons-react';
@@ -30,7 +30,12 @@ export function ShiftTypeSettings() {
   const [catalogOpened, setCatalogOpened] = useState(false);
   const [masterView, setMasterView] = useState<ShiftTypeDrawerState | null>(null);
   const [isEditorDirty, setEditorDirty] = useState(false);
+  const currentDepartmentCode = useRef(departmentCode);
   const { data: shiftTypes } = useDepartmentShiftTypes(departmentCode);
+
+  useEffect(() => {
+    currentDepartmentCode.current = departmentCode;
+  }, [departmentCode]);
 
   useEffect(() => {
     setSelectedShiftTypeId((current) =>
@@ -94,7 +99,12 @@ export function ShiftTypeSettings() {
               departmentCode={departmentCode}
               selectedShiftTypeId={selectedShiftTypeId}
               onSelect={selectShiftType}
-              onAdd={() => setCatalogOpened(true)}
+              canAssign={confirmDiscard}
+              onAssigned={(shiftTypeId, assignedDepartmentCode) => {
+                if (assignedDepartmentCode !== currentDepartmentCode.current) return;
+                setEditorDirty(false);
+                setSelectedShiftTypeId(shiftTypeId);
+              }}
               canRemove={(shiftTypeId) => shiftTypeId !== selectedShiftTypeId || confirmDiscard()}
             />
           </Paper>

--- a/src/features/shift-types/components/ShiftTypeSettings.tsx
+++ b/src/features/shift-types/components/ShiftTypeSettings.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { Drawer, Grid, Group, Modal, Paper, Stack, Tabs, Text } from '@mantine/core';
 import { IconArrowLeft, IconDatabase } from '@tabler/icons-react';
@@ -30,12 +30,8 @@ export function ShiftTypeSettings() {
   const [catalogOpened, setCatalogOpened] = useState(false);
   const [masterView, setMasterView] = useState<ShiftTypeDrawerState | null>(null);
   const [isEditorDirty, setEditorDirty] = useState(false);
-  const currentDepartmentCode = useRef(departmentCode);
+  const [isShiftTypeListDirty, setShiftTypeListDirty] = useState(false);
   const { data: shiftTypes } = useDepartmentShiftTypes(departmentCode);
-
-  useEffect(() => {
-    currentDepartmentCode.current = departmentCode;
-  }, [departmentCode]);
 
   useEffect(() => {
     setSelectedShiftTypeId((current) =>
@@ -46,17 +42,24 @@ export function ShiftTypeSettings() {
   }, [shiftTypes]);
 
   const blocker = useBlocker({
-    shouldBlockFn: () => isEditorDirty,
-    enableBeforeUnload: () => isEditorDirty,
+    shouldBlockFn: () => isEditorDirty || isShiftTypeListDirty,
+    enableBeforeUnload: () => isEditorDirty || isShiftTypeListDirty,
     withResolver: true,
   });
 
-  const confirmDiscard = useCallback(() => {
+  const confirmDiscardEditor = useCallback(() => {
     return !isEditorDirty || window.confirm('保存していない必要資格の変更を破棄しますか？');
   }, [isEditorDirty]);
 
+  const confirmDiscard = useCallback(() => {
+    return (
+      (!isEditorDirty && !isShiftTypeListDirty) ||
+      window.confirm('保存していないシフト種別設定の変更を破棄しますか？')
+    );
+  }, [isEditorDirty, isShiftTypeListDirty]);
+
   const selectShiftType = (shiftTypeId: string) => {
-    if (!confirmDiscard()) return;
+    if (!confirmDiscardEditor()) return;
     setEditorDirty(false);
     setSelectedShiftTypeId(shiftTypeId);
   };
@@ -65,6 +68,7 @@ export function ShiftTypeSettings() {
     const parsed = departmentCodeSchema.safeParse(value);
     if (!parsed.success || parsed.data === departmentCode || !confirmDiscard()) return;
     setEditorDirty(false);
+    setShiftTypeListDirty(false);
     setDepartmentCode(parsed.data);
   };
 
@@ -76,6 +80,7 @@ export function ShiftTypeSettings() {
           <AppButton
             intent="secondary"
             leftSection={<IconDatabase size={16} />}
+            disabled={isShiftTypeListDirty}
             onClick={() => setCatalogOpened(true)}
           >
             シフト種別マスタを管理
@@ -96,16 +101,19 @@ export function ShiftTypeSettings() {
         <Grid.Col span={{ base: 12, md: 4 }}>
           <Paper withBorder p="md">
             <DepartmentShiftTypeList
+              key={departmentCode}
               departmentCode={departmentCode}
               selectedShiftTypeId={selectedShiftTypeId}
               onSelect={selectShiftType}
-              canAssign={confirmDiscard}
-              onAssigned={(shiftTypeId, assignedDepartmentCode) => {
-                if (assignedDepartmentCode !== currentDepartmentCode.current) return;
+              canAssign={confirmDiscardEditor}
+              canRemove={(shiftTypeId) =>
+                shiftTypeId !== selectedShiftTypeId || confirmDiscardEditor()
+              }
+              onRemoved={(nextSelectedShiftTypeId) => {
                 setEditorDirty(false);
-                setSelectedShiftTypeId(shiftTypeId);
+                setSelectedShiftTypeId(nextSelectedShiftTypeId);
               }}
-              canRemove={(shiftTypeId) => shiftTypeId !== selectedShiftTypeId || confirmDiscard()}
+              onDirtyChange={setShiftTypeListDirty}
             />
           </Paper>
         </Grid.Col>
@@ -178,7 +186,7 @@ export function ShiftTypeSettings() {
         centered
       >
         <Stack>
-          <Text>このページを離れると、保存していない必要資格の変更は失われます。</Text>
+          <Text>このページを離れると、保存していないシフト種別設定の変更は失われます。</Text>
           <Group justify="flex-end">
             <AppButton intent="secondary" onClick={() => blocker.reset?.()}>
               このページに残る

--- a/src/features/shift-types/components/ShiftTypeSettings.tsx
+++ b/src/features/shift-types/components/ShiftTypeSettings.tsx
@@ -8,6 +8,7 @@ import { AppButton } from '@/components/AppButton';
 import { ListHeader } from '@/components/ListHeader';
 import { CertificationRankEditor } from '@/features/certification-requirements';
 import {
+  CreateDepartmentShiftTypeDialog,
   DepartmentShiftTypeCatalog,
   DepartmentShiftTypeList,
   useDepartmentShiftTypes,
@@ -25,6 +26,7 @@ import classes from './ShiftTypeSettings.module.css';
 export function ShiftTypeSettings() {
   const [departmentCode, setDepartmentCode] = useState<DepartmentCode>('ski');
   const [selectedShiftTypeId, setSelectedShiftTypeId] = useState<string | null>(null);
+  const [createDialogOpened, setCreateDialogOpened] = useState(false);
   const [catalogOpened, setCatalogOpened] = useState(false);
   const [masterView, setMasterView] = useState<ShiftTypeDrawerState | null>(null);
   const [isEditorDirty, setEditorDirty] = useState(false);
@@ -136,9 +138,28 @@ export function ShiftTypeSettings() {
             <ShiftTypeDrawerContent state={masterView} onDone={() => setMasterView(null)} />
           </Stack>
         ) : (
-          <DepartmentShiftTypeCatalog departmentCode={departmentCode} onOpenForm={setMasterView} />
+          <DepartmentShiftTypeCatalog
+            departmentCode={departmentCode}
+            onOpenForm={(state) => {
+              if (state.mode === 'create') {
+                setCreateDialogOpened(true);
+                return;
+              }
+              setMasterView(state);
+            }}
+          />
         )}
       </Drawer>
+
+      <CreateDepartmentShiftTypeDialog
+        opened={createDialogOpened}
+        departmentCode={departmentCode}
+        onClose={() => setCreateDialogOpened(false)}
+        onCreated={(shiftTypeId) => {
+          setCreateDialogOpened(false);
+          selectShiftType(shiftTypeId);
+        }}
+      />
 
       <Modal
         opened={blocker.status === 'blocked'}

--- a/src/features/shift-types/components/ShiftTypeSettings.tsx
+++ b/src/features/shift-types/components/ShiftTypeSettings.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 
 import { Drawer, Grid, Group, Modal, Paper, Stack, Tabs, Text } from '@mantine/core';
-import { IconArrowLeft, IconDatabase } from '@tabler/icons-react';
+import { IconDatabase } from '@tabler/icons-react';
 import { useBlocker } from '@tanstack/react-router';
 
 import { AppButton } from '@/components/AppButton';
@@ -19,7 +19,7 @@ import {
   type DepartmentCode,
 } from '@/features/departments/schema';
 
-import { ShiftTypeDrawerContent, type ShiftTypeDrawerState } from './ShiftTypeDrawer';
+import { EditShiftTypeDialog } from './EditShiftTypeDialog';
 import classes from './ShiftTypeSettings.module.css';
 
 /** 部門別シフト種別と必要資格を一続きで管理する画面。 */
@@ -28,7 +28,7 @@ export function ShiftTypeSettings() {
   const [selectedShiftTypeId, setSelectedShiftTypeId] = useState<string | null>(null);
   const [createDialogOpened, setCreateDialogOpened] = useState(false);
   const [catalogOpened, setCatalogOpened] = useState(false);
-  const [masterView, setMasterView] = useState<ShiftTypeDrawerState | null>(null);
+  const [editingShiftTypeId, setEditingShiftTypeId] = useState<string | null>(null);
   const [isEditorDirty, setEditorDirty] = useState(false);
   const [isShiftTypeListDirty, setShiftTypeListDirty] = useState(false);
   const { data: shiftTypes } = useDepartmentShiftTypes(departmentCode);
@@ -138,34 +138,19 @@ export function ShiftTypeSettings() {
         opened={catalogOpened}
         onClose={() => {
           setCatalogOpened(false);
-          setMasterView(null);
         }}
-        title={masterView ? 'シフト種別を登録・編集' : '共有シフト種別マスタ'}
+        title="共有シフト種別マスタ"
         size="xl"
       >
-        {masterView ? (
-          <Stack gap="md">
-            <AppButton
-              intent="tertiary"
-              leftSection={<IconArrowLeft size={16} />}
-              onClick={() => setMasterView(null)}
-              style={{ alignSelf: 'flex-start' }}
-            >
-              一覧へ戻る
-            </AppButton>
-            <ShiftTypeDrawerContent state={masterView} onDone={() => setMasterView(null)} />
-          </Stack>
-        ) : (
-          <DepartmentShiftTypeCatalog
-            onOpenForm={(state) => {
-              if (state.mode === 'create') {
-                setCreateDialogOpened(true);
-                return;
-              }
-              setMasterView(state);
-            }}
-          />
-        )}
+        <DepartmentShiftTypeCatalog
+          onOpenForm={(state) => {
+            if (state.mode === 'create') {
+              setCreateDialogOpened(true);
+              return;
+            }
+            setEditingShiftTypeId(state.shiftTypeId);
+          }}
+        />
       </Drawer>
 
       <CreateDepartmentShiftTypeDialog
@@ -176,6 +161,12 @@ export function ShiftTypeSettings() {
           setCreateDialogOpened(false);
           selectShiftType(shiftTypeId);
         }}
+      />
+
+      <EditShiftTypeDialog
+        opened={editingShiftTypeId !== null}
+        shiftTypeId={editingShiftTypeId}
+        onClose={() => setEditingShiftTypeId(null)}
       />
 
       <Modal

--- a/src/features/shift-types/components/ShiftTypeSettings.tsx
+++ b/src/features/shift-types/components/ShiftTypeSettings.tsx
@@ -157,7 +157,6 @@ export function ShiftTypeSettings() {
           </Stack>
         ) : (
           <DepartmentShiftTypeCatalog
-            departmentCode={departmentCode}
             onOpenForm={(state) => {
               if (state.mode === 'create') {
                 setCreateDialogOpened(true);

--- a/src/features/shifts/api.ts
+++ b/src/features/shifts/api.ts
@@ -135,7 +135,11 @@ async function findFrameQualificationRequirement(
   db: Database,
   departmentCode: string,
   shiftTypeId: string,
-): Promise<{ frameId: string; isRequired: boolean }> {
+): Promise<{
+  frameId: string;
+  certificationTiers: Array<{ certificationId: string; tierRank: number }>;
+  isRequired: boolean;
+}> {
   const [frame] = await db
     .select({ id: departmentShiftTypes.id })
     .from(departmentShiftTypes)
@@ -151,13 +155,19 @@ async function findFrameQualificationRequirement(
     throw new HTTPException(400, { message: '部門で利用できないシフト種別が含まれています' });
   }
 
-  const [requirement] = await db
-    .select({ id: certificationRequirements.id })
+  const certificationTiers = await db
+    .select({
+      certificationId: certificationRequirements.certificationId,
+      tierRank: certificationRequirements.tierRank,
+    })
     .from(certificationRequirements)
     .where(eq(certificationRequirements.departmentShiftTypeId, frame.id))
-    .limit(1);
+    .orderBy(
+      asc(certificationRequirements.tierRank),
+      asc(certificationRequirements.certificationId),
+    );
 
-  return { frameId: frame.id, isRequired: requirement !== undefined };
+  return { frameId: frame.id, certificationTiers, isRequired: certificationTiers.length > 0 };
 }
 
 /**
@@ -182,6 +192,7 @@ async function selectCandidatesForQualifiedFrame(
       lastNameKana: instructors.lastNameKana,
       firstNameKana: instructors.firstNameKana,
       status: instructors.status,
+      certificationId: certifications.id,
       certShortName: certifications.shortName,
     })
     .from(instructors)
@@ -201,6 +212,19 @@ async function selectCandidatesForQualifiedFrame(
       ),
     )
     .orderBy(asc(instructors.lastName), asc(instructors.firstName));
+}
+
+/** 候補行の資格が勤務種別の要件に含まれる場合だけ、表示用の資格情報へ変換する。 */
+function toRelevantCertification(
+  certificationId: string | null,
+  shortName: string | null,
+  tierRankByCertificationId: Map<string, number>,
+): { shortName: string; tierRank: number } | undefined {
+  if (!certificationId || !shortName) {
+    return undefined;
+  }
+  const tierRank = tierRankByCertificationId.get(certificationId);
+  return tierRank === undefined ? undefined : { shortName, tierRank };
 }
 
 /**
@@ -712,6 +736,7 @@ export const shiftsRoute = new Hono<{
             lastNameKana: instructors.lastNameKana,
             firstNameKana: instructors.firstNameKana,
             status: instructors.status,
+            certificationId: certifications.id,
             certShortName: certifications.shortName,
           })
           .from(instructors)
@@ -780,23 +805,31 @@ export const shiftsRoute = new Hono<{
       }
     }
 
-    // Instructor ごとに候補をグルーピングし、資格略称をまとめる
+    // Instructor ごとに候補をグルーピングし、この勤務種別の要件に該当する資格だけをまとめる。
     const assignedSet = new Set(assignedInstructorIds);
     type Candidate = {
       id: string;
       displayName: string;
       displayNameKana: string | null;
       status: string;
-      certShortNames: string[];
+      certifications: Array<{ shortName: string; tierRank: number }>;
       isAssigned: boolean;
       hasConflict: boolean;
     };
+    const tierRankByCertificationId = new Map(
+      frameRequirement.certificationTiers.map((tier) => [tier.certificationId, tier.tierRank]),
+    );
     const candidateMap = new Map<string, Candidate>();
     for (const row of candidateRows) {
       const existing = candidateMap.get(row.id);
+      const relevantCertification = toRelevantCertification(
+        row.certificationId,
+        row.certShortName,
+        tierRankByCertificationId,
+      );
       if (existing) {
-        if (row.certShortName) {
-          existing.certShortNames.push(row.certShortName);
+        if (relevantCertification) {
+          existing.certifications.push(relevantCertification);
         }
       } else {
         candidateMap.set(row.id, {
@@ -804,7 +837,7 @@ export const shiftsRoute = new Hono<{
           displayName: formatName(row.lastName, row.firstName),
           displayNameKana: formatNameKana(row.lastNameKana, row.firstNameKana),
           status: row.status,
-          certShortNames: row.certShortName ? [row.certShortName] : [],
+          certifications: relevantCertification ? [relevantCertification] : [],
           isAssigned: assignedSet.has(row.id),
           hasConflict: conflictByInstructor.has(row.id),
         });
@@ -816,7 +849,10 @@ export const shiftsRoute = new Hono<{
       displayName: cand.displayName,
       displayNameKana: cand.displayNameKana,
       status: cand.status,
-      certifications: cand.certShortNames,
+      certifications: cand.certifications.sort(
+        (left, right) =>
+          left.tierRank - right.tierRank || left.shortName.localeCompare(right.shortName, 'ja-JP'),
+      ),
       isAssigned: cand.isAssigned,
       hasConflict: cand.hasConflict,
       hasQualificationWarning:

--- a/src/features/shifts/api.ts
+++ b/src/features/shifts/api.ts
@@ -1,4 +1,19 @@
-import { and, asc, count, desc, eq, exists, gte, inArray, lt, lte, ne, or, sql } from 'drizzle-orm';
+import {
+  and,
+  asc,
+  count,
+  desc,
+  eq,
+  exists,
+  gte,
+  inArray,
+  lt,
+  lte,
+  ne,
+  or,
+  sql,
+  type SQL,
+} from 'drizzle-orm';
 import type { BatchItem } from 'drizzle-orm/batch';
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
@@ -227,8 +242,76 @@ function toRelevantCertification(
   return tierRank === undefined ? undefined : { shortName, tierRank };
 }
 
+/** 資格要件に該当する割り当てごとに、最上位の資格ランクを対応付ける。 */
+function indexBestCertificationTier(
+  rows: Array<{ shiftId: string; instructorId: string; tierRank: number }>,
+): Map<string, number> {
+  const tierRankByAssignment = new Map<string, number>();
+  for (const row of rows) {
+    const key = `${row.shiftId}:${row.instructorId}`;
+    const current = tierRankByAssignment.get(key);
+    if (current === undefined || row.tierRank < current) {
+      tierRankByAssignment.set(key, row.tierRank);
+    }
+  }
+  return tierRankByAssignment;
+}
+
+/** シフトの絞り込み条件に一致する、資格要件を満たす割り当ての資格ランクを取得する。 */
+async function loadCertificationTierRows(
+  db: Database,
+  condition: SQL<unknown> | undefined,
+): Promise<Array<{ shiftId: string; instructorId: string; tierRank: number }>> {
+  return db
+    .select({
+      shiftId: shiftAssignments.shiftId,
+      instructorId: shiftAssignments.instructorId,
+      tierRank: certificationRequirements.tierRank,
+    })
+    .from(shiftAssignments)
+    .innerJoin(shifts, eq(shifts.id, shiftAssignments.shiftId))
+    .innerJoin(
+      departmentShiftTypes,
+      and(
+        eq(departmentShiftTypes.departmentCode, shifts.departmentCode),
+        eq(departmentShiftTypes.shiftTypeId, shifts.shiftTypeId),
+      ),
+    )
+    .innerJoin(
+      certificationRequirements,
+      eq(certificationRequirements.departmentShiftTypeId, departmentShiftTypes.id),
+    )
+    .innerJoin(
+      instructorCertifications,
+      and(
+        eq(instructorCertifications.instructorId, shiftAssignments.instructorId),
+        eq(instructorCertifications.certificationId, certificationRequirements.certificationId),
+      ),
+    )
+    .where(condition);
+}
+
+type RankedAssignedInstructor = {
+  id: string;
+  displayName: string;
+  displayNameKana: string | null;
+  tierRank: number | undefined;
+};
+
+/** 担当者を資格ランクの昇順、同ランクと資格なしはかな順で並べる。 */
+function sortAssignedInstructors(assigned: RankedAssignedInstructor[]): void {
+  assigned.sort(
+    (left, right) =>
+      (left.tierRank ?? Number.POSITIVE_INFINITY) - (right.tierRank ?? Number.POSITIVE_INFINITY) ||
+      (left.displayNameKana ?? left.displayName).localeCompare(
+        right.displayNameKana ?? right.displayName,
+        'ja-JP',
+      ),
+  );
+}
+
 /**
- * 指定期間 [from, to]（両端含む）のシフトを表示ビュー用に整形する（2クエリ・N+1 なし）。
+ * 指定期間 [from, to]（両端含む）のシフトを表示ビュー用に整形する（3クエリ・N+1 なし）。
  * shifts × shiftTypes を JOIN し、割り当てを別クエリでまとめて付与する。
  * カレンダービュー（月次）が使う読み取りロジック。
  */
@@ -264,6 +347,8 @@ async function loadShiftView(db: Database, from: Date, to: Date): Promise<ShiftV
             instructorId: instructors.id,
             lastName: instructors.lastName,
             firstName: instructors.firstName,
+            lastNameKana: instructors.lastNameKana,
+            firstNameKana: instructors.firstNameKana,
           })
           .from(shiftAssignments)
           .innerJoin(instructors, eq(instructors.id, shiftAssignments.instructorId))
@@ -271,16 +356,29 @@ async function loadShiftView(db: Database, from: Date, to: Date): Promise<ShiftV
           .where(and(gte(shifts.date, from), lte(shifts.date, to)))
       : [];
 
-  // shiftId → 割り当て済み Instructor（表示名付き）のマップを1パスで構築する
-  const assignedByShift = new Map<string, { id: string; displayName: string }[]>();
+  // 枠の資格要件と保有資格が一致する担当者だけを集計し、各担当者の最上位ランクを取得する。
+  // 要件外資格しか持たない担当者は結果に含めず、後段で資格なしとしてかな順に並べる。
+  const certificationTierRows =
+    shiftRows.length > 0
+      ? await loadCertificationTierRows(db, and(gte(shifts.date, from), lte(shifts.date, to)))
+      : [];
+
+  const tierRankByAssignment = indexBestCertificationTier(certificationTierRows);
+
+  // shiftId → 資格順に並べた割り当て済み Instructor（表示名付き）のマップを構築する。
+  const assignedByShift = new Map<string, RankedAssignedInstructor[]>();
   for (const row of assignRows) {
     const list = assignedByShift.get(row.shiftId) ?? [];
     list.push({
       id: row.instructorId,
       displayName: formatName(row.lastName, row.firstName),
+      displayNameKana: formatNameKana(row.lastNameKana, row.firstNameKana),
+      tierRank: tierRankByAssignment.get(`${row.shiftId}:${row.instructorId}`),
     });
     assignedByShift.set(row.shiftId, list);
   }
+
+  for (const assigned of assignedByShift.values()) sortAssignedInstructors(assigned);
 
   return shiftRows.map((s) => {
     const code = departmentCodeSchema.parse(s.departmentCode);
@@ -293,13 +391,16 @@ async function loadShiftView(db: Database, from: Date, to: Date): Promise<ShiftV
         code,
       },
       shiftType: { id: s.shiftTypeId, name: s.shiftTypeName },
-      assignedInstructors: assignedByShift.get(s.id) ?? [],
+      assignedInstructors: (assignedByShift.get(s.id) ?? []).map(({ id, displayName }) => ({
+        id,
+        displayName,
+      })),
     };
   });
 }
 
 /**
- * 指定された日付群のシフトを表示ビュー用に整形する（2クエリ・N+1 なし）。
+ * 指定された日付群のシフトを表示ビュー用に整形する（3クエリ・N+1 なし）。
  * アジェンダでは先に稼働日だけをページングし、その日付群に属する Shift 詳細だけを取得する。
  */
 async function loadShiftViewByDates(
@@ -347,6 +448,8 @@ async function loadShiftViewByDates(
             instructorId: instructors.id,
             lastName: instructors.lastName,
             firstName: instructors.firstName,
+            lastNameKana: instructors.lastNameKana,
+            firstNameKana: instructors.firstNameKana,
           })
           .from(shiftAssignments)
           .innerJoin(instructors, eq(instructors.id, shiftAssignments.instructorId))
@@ -355,15 +458,24 @@ async function loadShiftViewByDates(
           .orderBy(asc(instructors.lastName), asc(instructors.firstName))
       : [];
 
-  const assignedByShift = new Map<string, { id: string; displayName: string }[]>();
+  const certificationTierRows =
+    shiftRows.length > 0 ? await loadCertificationTierRows(db, and(...conditions)) : [];
+
+  const tierRankByAssignment = indexBestCertificationTier(certificationTierRows);
+
+  const assignedByShift = new Map<string, RankedAssignedInstructor[]>();
   for (const row of assignRows) {
     const list = assignedByShift.get(row.shiftId) ?? [];
     list.push({
       id: row.instructorId,
       displayName: formatName(row.lastName, row.firstName),
+      displayNameKana: formatNameKana(row.lastNameKana, row.firstNameKana),
+      tierRank: tierRankByAssignment.get(`${row.shiftId}:${row.instructorId}`),
     });
     assignedByShift.set(row.shiftId, list);
   }
+
+  for (const assigned of assignedByShift.values()) sortAssignedInstructors(assigned);
 
   return shiftRows.map((s) => {
     const code = departmentCodeSchema.parse(s.departmentCode);
@@ -376,7 +488,10 @@ async function loadShiftViewByDates(
         code,
       },
       shiftType: { id: s.shiftTypeId, name: s.shiftTypeName },
-      assignedInstructors: assignedByShift.get(s.id) ?? [],
+      assignedInstructors: (assignedByShift.get(s.id) ?? []).map(({ id, displayName }) => ({
+        id,
+        displayName,
+      })),
     };
   });
 }

--- a/src/features/shifts/candidate-display.ts
+++ b/src/features/shifts/candidate-display.ts
@@ -1,0 +1,41 @@
+/** 割り当て候補に表示する、勤務種別に該当する資格。 */
+export type RelevantCertification = {
+  shortName: string;
+  tierRank: number;
+};
+
+/** 資格順に並べる候補が持つ最小限の情報。 */
+export type CertificationSortableCandidate = {
+  displayName: string;
+  displayNameKana: string | null;
+  certifications: RelevantCertification[];
+};
+
+/**
+ * 候補の該当資格のうち最上位のランクを返す。
+ * ランク値が小さいほど上位であり、該当資格を持たない候補は末尾へ並べる。
+ */
+export function bestCertificationTier(candidate: CertificationSortableCandidate): number {
+  return candidate.certifications.reduce(
+    (best, certification) => Math.min(best, certification.tierRank),
+    Number.POSITIVE_INFINITY,
+  );
+}
+
+/** 資格ランクの昇順（上位から）、同ランク内はかな順で候補を比較する。 */
+export function compareInstructorCertification(
+  a: CertificationSortableCandidate,
+  b: CertificationSortableCandidate,
+): number {
+  return bestCertificationTier(a) - bestCertificationTier(b) || compareInstructorKana(a, b);
+}
+
+/** 表示名のかな順で候補を比較する。 */
+export function compareInstructorKana(
+  a: Pick<CertificationSortableCandidate, 'displayName' | 'displayNameKana'>,
+  b: Pick<CertificationSortableCandidate, 'displayName' | 'displayNameKana'>,
+): number {
+  const aKey = a.displayNameKana ?? a.displayName;
+  const bKey = b.displayNameKana ?? b.displayName;
+  return aKey.localeCompare(bKey, 'ja-JP');
+}

--- a/src/features/shifts/components/ShiftManager.tsx
+++ b/src/features/shifts/components/ShiftManager.tsx
@@ -40,6 +40,7 @@ import { departmentCodeSchema, type DepartmentCode } from '@/features/department
 
 import type { AutoAssignSolver } from '../auto-assign-solver-port';
 import { createWorkerSolver } from '../auto-assign-worker-solver';
+import { compareInstructorCertification, compareInstructorKana } from '../candidate-display';
 import {
   useAutoAssignContext,
   useShiftAssignmentEditor,
@@ -73,7 +74,7 @@ const ASSIGNMENT_DRAWER_HEIGHT = '55vh';
  */
 const autoAssignSolver: AutoAssignSolver = createWorkerSolver();
 
-type CandidateSortMode = 'kana' | 'workload';
+type CandidateSortMode = 'certification' | 'kana' | 'workload';
 
 type SelectedCell = ShiftManagerSelection;
 
@@ -1058,7 +1059,7 @@ function AssignmentPanel({
   }, [editData.data, onRegisterInstructorNames]);
 
   const [search, setSearch] = useState('');
-  const [sortMode, setSortMode] = useState<CandidateSortMode>('kana');
+  const [sortMode, setSortMode] = useState<CandidateSortMode>('certification');
 
   // 表示・編集対象の割り当て内容: stagedCell 優先、無ければサーバー state。
   const stagedInstructorIds = stagedCell?.instructorIds;
@@ -1099,13 +1100,17 @@ function AssignmentPanel({
           .toLocaleLowerCase('ja-JP')
           .includes(query);
       })
-      .sort(
-        sortMode === 'workload'
-          ? (a, b) =>
-              (loadByInstructor.get(a.id) ?? 0) - (loadByInstructor.get(b.id) ?? 0) ||
-              compareInstructorKana(a, b)
-          : compareInstructorKana,
-      );
+      .sort((a, b) => {
+        if (sortMode === 'workload') {
+          return (
+            (loadByInstructor.get(a.id) ?? 0) - (loadByInstructor.get(b.id) ?? 0) ||
+            compareInstructorKana(a, b)
+          );
+        }
+        return sortMode === 'certification'
+          ? compareInstructorCertification(a, b)
+          : compareInstructorKana(a, b);
+      });
   }, [editData.data?.availableInstructors, search, sortMode, loadByInstructor]);
 
   const availabilityByInstructor = useMemo(
@@ -1157,6 +1162,7 @@ function AssignmentPanel({
               value={sortMode}
               onChange={(value) => setSortMode(parseCandidateSortMode(value))}
               data={[
+                { value: 'certification', label: '資格順' },
                 { value: 'kana', label: 'かな順' },
                 { value: 'workload', label: '負荷が低い順' },
               ]}
@@ -1311,14 +1317,14 @@ function InstructorCard({
                 </Group>
                 {instructor.certifications.length > 0 && (
                   <Group gap={4} wrap="wrap">
-                    {instructor.certifications.map((cert, index) => (
+                    {instructor.certifications.map((cert) => (
                       <AppBadge
-                        key={index}
+                        key={`${cert.shortName}:${cert.tierRank}`}
                         kind="certification"
                         departmentCode={departmentCode}
                         size="xs"
                       >
-                        {cert}
+                        {cert.shortName}
                       </AppBadge>
                     ))}
                   </Group>
@@ -1404,12 +1410,9 @@ function weekdayLabel(date: string): string {
   return ['日', '月', '火', '水', '木', '金', '土'][weekdayIndex(date)] ?? '';
 }
 
-function compareInstructorKana(a: AvailableInstructor, b: AvailableInstructor): number {
-  const aKey = a.displayNameKana ?? a.displayName;
-  const bKey = b.displayNameKana ?? b.displayName;
-  return aKey.localeCompare(bKey, 'ja-JP');
-}
-
 function parseCandidateSortMode(value: string): CandidateSortMode {
-  return value === 'workload' ? 'workload' : 'kana';
+  if (value === 'workload' || value === 'kana' || value === 'certification') {
+    return value;
+  }
+  return 'certification';
 }

--- a/src/features/shifts/components/ShiftManager.tsx
+++ b/src/features/shifts/components/ShiftManager.tsx
@@ -1257,7 +1257,7 @@ function InstructorCard({
       : availability?.type === 'UNAVAILABLE'
         ? `勤務不可${availability.note ? `: ${availability.note}` : ''}`
         : availabilityStatus === 'NOT_LINKED'
-          ? '入力不能（user未連携）'
+          ? '未連携'
           : availabilityStatus === 'NOT_SUBMITTED'
             ? '未入力（userリンク済み・申告なし）'
             : undefined;
@@ -1311,7 +1311,7 @@ function InstructorCard({
                   )}
                   {!availability && availabilityStatus === 'NOT_LINKED' && (
                     <AppBadge kind="inactive" size="xs">
-                      入力不能
+                      未連携
                     </AppBadge>
                   )}
                 </Group>

--- a/src/features/shifts/schema.ts
+++ b/src/features/shifts/schema.ts
@@ -195,8 +195,13 @@ const availableInstructorSchema = z.object({
   displayName: z.string(),
   displayNameKana: z.string().nullable(),
   status: z.string(),
-  /** 保有資格の略称一覧 */
-  certifications: z.array(z.string()),
+  /** 勤務種別に該当する保有資格（上位ランク順） */
+  certifications: z.array(
+    z.object({
+      shortName: z.string(),
+      tierRank: z.number().int().positive(),
+    }),
+  ),
   /** この Shift に既に割り当て済みか */
   isAssigned: z.boolean(),
   /** 同日の別 Shift に割り当て済みで競合しているか */

--- a/test/candidate-display.test.ts
+++ b/test/candidate-display.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  bestCertificationTier,
+  compareInstructorCertification,
+  type CertificationSortableCandidate,
+} from '../src/features/shifts/candidate-display';
+
+describe('資格順の候補比較', () => {
+  it('該当資格の最上位ランク順に並べ、同ランクではかな順にする', () => {
+    const candidates: CertificationSortableCandidate[] = [
+      { displayName: '山田 太郎', displayNameKana: 'ヤマダ タロウ', certifications: [] },
+      {
+        displayName: '鈴木 花子',
+        displayNameKana: 'スズキ ハナコ',
+        certifications: [{ shortName: '準指導員', tierRank: 2 }],
+      },
+      {
+        displayName: '佐藤 次郎',
+        displayNameKana: 'サトウ ジロウ',
+        certifications: [
+          { shortName: '準指導員', tierRank: 2 },
+          { shortName: '指導員', tierRank: 1 },
+        ],
+      },
+      {
+        displayName: '佐々木 三郎',
+        displayNameKana: 'ササキ サブロウ',
+        certifications: [{ shortName: '検定員', tierRank: 1 }],
+      },
+    ];
+
+    expect(
+      [...candidates]
+        .sort(compareInstructorCertification)
+        .map((candidate) => candidate.displayName),
+    ).toEqual(['佐々木 三郎', '佐藤 次郎', '鈴木 花子', '山田 太郎']);
+    expect(bestCertificationTier(candidates[2]!)).toBe(1);
+  });
+});

--- a/test/department-shift-types.integration.test.ts
+++ b/test/department-shift-types.integration.test.ts
@@ -166,7 +166,7 @@ describe('PUT /api/department-shift-types/:departmentCode', () => {
     expect(res.status).toBe(400);
   });
 
-  it('追加または除外を含む配列を 400 で拒否する', async () => {
+  it('追加と除外を含む配列で可用集合をまとめて更新する', async () => {
     const db = createDb(env.DB);
     const [assigned, unassigned] = await db
       .insert(shiftTypes)
@@ -191,16 +191,18 @@ describe('PUT /api/department-shift-types/:departmentCode', () => {
       envWith({}),
     );
 
-    expect(addRes.status).toBe(400);
-    expect(removeRes.status).toBe(400);
+    expect(addRes.status).toBe(200);
+    expect(departmentShiftTypeListSchema.parse(await addRes.json())).toMatchObject([
+      { shiftTypeId: assigned.id, sortOrder: 1 },
+      { shiftTypeId: unassigned.id, sortOrder: 2 },
+    ]);
+    expect(removeRes.status).toBe(200);
     const assignmentsRes = await app.request(
       '/api/department-shift-types/ski',
       authRequest(token),
       envWith({}),
     );
-    expect(departmentShiftTypeListSchema.parse(await assignmentsRes.json())).toMatchObject([
-      { shiftTypeId: assigned.id },
-    ]);
+    expect(departmentShiftTypeListSchema.parse(await assignmentsRes.json())).toEqual([]);
   });
 });
 

--- a/test/department-shift-types.integration.test.ts
+++ b/test/department-shift-types.integration.test.ts
@@ -9,7 +9,13 @@ import {
 import app from '../src/index';
 import { signJwt } from '../src/server/auth/jwt';
 import { createDb } from '../src/server/db/client';
-import { departmentShiftTypes, shiftTypes, users } from '../src/server/db/schema';
+import {
+  certificationRequirements,
+  certifications,
+  departmentShiftTypes,
+  shiftTypes,
+  users,
+} from '../src/server/db/schema';
 import type { Env } from '../src/server/types';
 
 function envWith(overrides: Partial<Env>): Env {
@@ -53,7 +59,9 @@ async function seedToken(role: 'ADMIN' | 'MANAGER' | 'MEMBER'): Promise<string> 
 
 beforeEach(async () => {
   const db = createDb(env.DB);
+  await db.delete(certificationRequirements);
   await db.delete(departmentShiftTypes);
+  await db.delete(certifications);
   await db.delete(shiftTypes);
   await db.delete(users);
 });
@@ -133,6 +141,60 @@ describe('PUT /api/department-shift-types/:departmentCode', () => {
     expect(body.map(({ shiftTypeId, sortOrder }) => ({ shiftTypeId, sortOrder }))).toEqual([
       { shiftTypeId: second.id, sortOrder: 1 },
       { shiftTypeId: first.id, sortOrder: 2 },
+    ]);
+  });
+
+  it('並べ替えても継続する種別の資格要件を保持する', async () => {
+    const db = createDb(env.DB);
+    const [first, second] = await db
+      .insert(shiftTypes)
+      .values([{ name: '終日' }, { name: '午前' }])
+      .returning();
+    const [certification] = await db
+      .insert(certifications)
+      .values({
+        departmentCode: 'ski',
+        name: '指導員',
+        shortName: '指導員',
+        organization: 'テスト連盟',
+      })
+      .returning();
+    if (!first || !second || !certification) {
+      throw new Error('テストデータの作成に失敗しました');
+    }
+    await db.insert(departmentShiftTypes).values([
+      { departmentCode: 'ski', shiftTypeId: first.id, sortOrder: 1 },
+      { departmentCode: 'ski', shiftTypeId: second.id, sortOrder: 2 },
+    ]);
+    const token = await seedToken('ADMIN');
+
+    const requirementsRes = await app.request(
+      `/api/certification-requirements/ski/${first.id}`,
+      {
+        method: 'PUT',
+        ...authRequest(token, {
+          certifications: [{ certificationId: certification.id, tierRank: 1 }],
+        }),
+      },
+      envWith({}),
+    );
+    expect(requirementsRes.status).toBe(200);
+
+    const reorderRes = await app.request(
+      '/api/department-shift-types/ski',
+      { method: 'PUT', ...authRequest(token, { shiftTypeIds: [second.id, first.id] }) },
+      envWith({}),
+    );
+    expect(reorderRes.status).toBe(200);
+
+    const getRequirementsRes = await app.request(
+      `/api/certification-requirements/ski/${first.id}`,
+      authRequest(token),
+      envWith({}),
+    );
+    expect(getRequirementsRes.status).toBe(200);
+    expect(await getRequirementsRes.json()).toEqual([
+      { certificationId: certification.id, tierRank: 1 },
     ]);
   });
 

--- a/test/shift-view.integration.test.ts
+++ b/test/shift-view.integration.test.ts
@@ -1,4 +1,5 @@
 import { env } from 'cloudflare:test';
+import { and, eq } from 'drizzle-orm';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import {
@@ -10,7 +11,10 @@ import app from '../src/index';
 import { signJwt } from '../src/server/auth/jwt';
 import { createDb } from '../src/server/db/client';
 import {
+  certificationRequirements,
+  certifications,
   departmentShiftTypes,
+  instructorCertifications,
   instructors,
   shiftAssignments,
   shifts,
@@ -104,6 +108,56 @@ async function seedInstructor(lastName: string, firstName: string): Promise<stri
   return inst.id;
 }
 
+async function seedCertification(departmentCode: string, shortName: string): Promise<string> {
+  const db = createDb(env.DB);
+  const [certification] = await db
+    .insert(certifications)
+    .values({
+      departmentCode,
+      name: `${shortName}資格`,
+      shortName,
+      organization: 'テスト団体',
+      isActive: true,
+    })
+    .returning();
+  if (!certification) {
+    throw new Error('seedCertification: insert failed');
+  }
+  return certification.id;
+}
+
+async function assignCertification(instructorId: string, certificationId: string): Promise<void> {
+  const db = createDb(env.DB);
+  await db.insert(instructorCertifications).values({ instructorId, certificationId });
+}
+
+async function requireCertification(
+  departmentCode: string,
+  shiftTypeId: string,
+  certificationId: string,
+  tierRank: number,
+): Promise<void> {
+  const db = createDb(env.DB);
+  const [frame] = await db
+    .select({ id: departmentShiftTypes.id })
+    .from(departmentShiftTypes)
+    .where(
+      and(
+        eq(departmentShiftTypes.departmentCode, departmentCode),
+        eq(departmentShiftTypes.shiftTypeId, shiftTypeId),
+      ),
+    )
+    .limit(1);
+  if (!frame) {
+    throw new Error('requireCertification: frame not found');
+  }
+  await db.insert(certificationRequirements).values({
+    departmentShiftTypeId: frame.id,
+    certificationId,
+    tierRank,
+  });
+}
+
 /** 指定日（YYYY-MM-DD）にシフトを直接 INSERT し、割り当てを付与する */
 async function seedShift(
   dateStr: string,
@@ -130,9 +184,12 @@ beforeEach(async () => {
   const db = createDb(env.DB);
   await db.delete(shiftAssignments);
   await db.delete(shifts);
+  await db.delete(certificationRequirements);
   await db.delete(departmentShiftTypes);
   await db.delete(shiftTypes);
+  await db.delete(instructorCertifications);
   await db.delete(instructors);
+  await db.delete(certifications);
   await db.delete(users);
 });
 
@@ -264,6 +321,58 @@ describe('GET /api/shifts/calendar', () => {
     expect(res.status).toBe(200);
     const body = shiftViewResponseSchema.parse(await res.json());
     expect(body.shifts.map((shift) => shift.shiftType.name)).toEqual(['午後', '終日', '午前']);
+  });
+
+  it('カレンダー・アジェンダ・出勤状況の担当者を資格ランク順にする', async () => {
+    const ski = await seedDepartment('スキー', 'ski');
+    const shiftTypeId = await seedShiftType('終日', ['ski']);
+    const top = await seedInstructor('鈴木', '花子');
+    const lower = await seedInstructor('佐藤', '次郎');
+    const unqualified = await seedInstructor('山田', '太郎');
+    const topCertification = await seedCertification(ski, '指導員');
+    const lowerCertification = await seedCertification(ski, '準指導員');
+    await assignCertification(top, topCertification);
+    await assignCertification(lower, lowerCertification);
+    await requireCertification(ski, shiftTypeId, lowerCertification, 2);
+    await requireCertification(ski, shiftTypeId, topCertification, 1);
+    await seedShift('2026-01-10', ski, shiftTypeId, [unqualified, lower, top]);
+    const token = await seedToken('MEMBER');
+
+    const res = await app.request(
+      '/api/shifts/calendar?month=2026-01',
+      authHeader(token),
+      envWith({}),
+    );
+
+    expect(res.status).toBe(200);
+    const body = shiftViewResponseSchema.parse(await res.json());
+    expect(body.shifts[0]?.assignedInstructors.map((instructor) => instructor.displayName)).toEqual(
+      ['鈴木 花子', '佐藤 次郎', '山田 太郎'],
+    );
+
+    const agendaRes = await app.request(
+      '/api/shifts/agenda?cursor=2026-01-10&direction=future',
+      authHeader(token),
+      envWith({}),
+    );
+    expect(agendaRes.status).toBe(200);
+    const agenda = shiftAgendaResponseSchema.parse(await agendaRes.json());
+    expect(
+      agenda.days[0]?.shifts[0]?.assignedInstructors.map((instructor) => instructor.displayName),
+    ).toEqual(['鈴木 花子', '佐藤 次郎', '山田 太郎']);
+
+    const attendanceRes = await app.request(
+      '/api/shifts/attendance?dates=2026-01-10',
+      authHeader(token),
+      envWith({}),
+    );
+    expect(attendanceRes.status).toBe(200);
+    const attendance = shiftAttendanceSchema.parse(await attendanceRes.json());
+    expect(attendance[0]?.assignedInstructors.map((instructor) => instructor.displayName)).toEqual([
+      '鈴木 花子',
+      '佐藤 次郎',
+      '山田 太郎',
+    ]);
   });
 
   it('未認証は 401 を返す', async () => {

--- a/test/shifts.integration.test.ts
+++ b/test/shifts.integration.test.ts
@@ -93,14 +93,18 @@ async function seedShiftType(name = '終日', isActive = true): Promise<string> 
   return st.id;
 }
 
-async function seedCertification(departmentCode: string, name = 'スキー指導員'): Promise<string> {
+async function seedCertification(
+  departmentCode: string,
+  name = 'スキー指導員',
+  shortName = '指導員',
+): Promise<string> {
   const db = createDb(env.DB);
   const [cert] = await db
     .insert(certifications)
     .values({
       departmentCode,
       name,
-      shortName: '指導員',
+      shortName,
       organization: '全日本スキー連盟',
       isActive: true,
     })
@@ -135,6 +139,7 @@ async function requireFrameCertification(
   departmentCode: string,
   shiftTypeId: string,
   certificationId: string,
+  tierRank = 1,
 ): Promise<void> {
   const db = createDb(env.DB);
   const [frame] = await db
@@ -153,7 +158,7 @@ async function requireFrameCertification(
   await db.insert(certificationRequirements).values({
     departmentShiftTypeId: frame.id,
     certificationId,
-    tierRank: 1,
+    tierRank,
   });
 }
 
@@ -898,7 +903,7 @@ describe('GET /api/shifts/assignment-editor', () => {
     expect(body.availableInstructors).toHaveLength(1);
     expect(body.availableInstructors[0]?.id).toBe(inst);
     expect(body.availableInstructors[0]?.isAssigned).toBe(false);
-    expect(body.availableInstructors[0]?.certifications).toEqual(['指導員']);
+    expect(body.availableInstructors[0]?.certifications).toEqual([]);
   });
 
   it('既存シフトがあれば edit モードで割り当て状態を返す', async () => {
@@ -932,6 +937,7 @@ describe('GET /api/shifts/assignment-editor', () => {
     const otherInstructorId = await seedInstructor('鈴木', '花子');
     const token = await seedToken('MANAGER');
     await linkCertification(qualifiedInstructorId, requiredCertificationId);
+    await linkCertification(qualifiedInstructorId, otherCertificationId);
     await linkCertification(otherInstructorId, otherCertificationId);
     await requireFrameCertification(departmentCode, shiftTypeId, requiredCertificationId);
 
@@ -944,6 +950,36 @@ describe('GET /api/shifts/assignment-editor', () => {
     const body = shiftEditDataSchema.parse(await res.json());
     expect(body.availableInstructors.map((instructor) => instructor.id)).toEqual([
       qualifiedInstructorId,
+    ]);
+    expect(body.availableInstructors[0]?.certifications).toEqual([
+      { shortName: '指導員', tierRank: 1 },
+    ]);
+  });
+
+  it('該当資格だけをランク順に返す', async () => {
+    const departmentCode = await seedDepartment();
+    const shiftTypeId = await seedShiftType();
+    const topCertificationId = await seedCertification(departmentCode, '指導員', '指導員');
+    const lowerCertificationId = await seedCertification(departmentCode, '準指導員', '準指導員');
+    const unrelatedCertificationId = await seedCertification(departmentCode, '検定員', '検定員');
+    const instructorId = await seedInstructor('山田', '太郎');
+    const token = await seedToken('MANAGER');
+    await linkCertification(instructorId, lowerCertificationId);
+    await linkCertification(instructorId, unrelatedCertificationId);
+    await linkCertification(instructorId, topCertificationId);
+    await requireFrameCertification(departmentCode, shiftTypeId, lowerCertificationId, 2);
+    await requireFrameCertification(departmentCode, shiftTypeId, topCertificationId, 1);
+
+    const res = await app.request(
+      `/api/shifts/assignment-editor?date=2026-01-15&departmentCode=${departmentCode}&shiftTypeId=${shiftTypeId}`,
+      authHeader(token),
+      envWith({}),
+    );
+
+    const body = shiftEditDataSchema.parse(await res.json());
+    expect(body.availableInstructors[0]?.certifications).toEqual([
+      { shortName: '指導員', tierRank: 1 },
+      { shortName: '準指導員', tierRank: 2 },
     ]);
   });
 


### PR DESCRIPTION
## 概要

部門別シフト種別の登録・編集を一括保存方式のUIに刷新し、勤務種別ごとの資格要件を設定できるようにした。
割当候補・担当者の表示順を資格ランク基準に統一し、開発シードにも部門別シフト種別と資格要件を追加した。

## やったこと

- シフト種別の追加をコンパクトな登録ダイアログに変更し、登録と部門割当を同時に完了できるようにする
- 部門で利用するシフト種別をセレクトから直接追加できるように改善する
- 部門別シフト種別の追加・除外・並び替えをステージし、一括保存できるように変更する（未保存変更の確認付き）
- シフト種別マスタ管理ドロワーから部門への即時追加操作を削除し、追加操作をメイン画面の一括保存に統一する
- シフト種別マスタの編集を登録と同じモーダル表示に統一する
- 開発シードにシフト種別の部門別設定（表示順）を追加する
- 開発シードに部門別シフト種別の資格要件（対象資格・ランク）を追加する
- シード投入時の対象資格を短縮名で指定し、並び順への依存をなくす
- シード時に対象資格の短縮名が部門内で一意であることを検証する
- 勤務種別に該当する資格だけを割当候補に表示し、資格ランク順に並べる
- 未連携ユーザーの割当候補表示・文言を「未連携」に統一する
- シフト枠の担当者表示順を資格ランク基準に統一する（カレンダー・アジェンダ・出勤状況）

## レビューポイント

- `loadShiftView` / `loadShiftViewByDates` が資格ランク集計のため2クエリ→3クエリ構成になっている（`src/features/shifts/api.ts`）。パフォーマンス影響がないか確認したい
- `availableInstructorSchema.certifications` の型を `string[]` から `{ shortName, tierRank }[]` に変更している。このスキーマを参照するクライアント側に影響がないか確認したい

## 備考

- DBスキーマ変更は伴わないため、マイグレーションは不要
