### PR TITLE
⚡️ Tune staleTime and redirect expired sessions

### DIFF
--- a/src/features/auth/auth-guard.ts
+++ b/src/features/auth/auth-guard.ts
@@ -1,30 +1,15 @@
 import type { QueryClient } from '@tanstack/react-query';
 
-import { client } from '@/lib/rpc';
-
-import { ME_QUERY_KEY } from './queries';
-import { meResponseSchema, type MeResponse } from './schema';
+import { meQueryOptions } from './queries';
+import type { MeResponse } from './schema';
 
 /**
  * 現在の認証状態を取得する（未認証なら null）。
  * TanStack Query のキャッシュを共有し、ルートガードとコンポーネント表示で同じ結果を使う。
- * 親レイアウトルートで `ensureAuthenticated` を通過した後、子ルートでロールなどの追加チェックを
- * 行うときはこの関数を使うとキャッシュヒットで済み、余分な API 呼び出しが発生しない。
+ * 認証主体の取り違えを避けるため、グローバルの `staleTime` に関係なく毎回再検証する。
  */
 export async function fetchMe(queryClient: QueryClient): Promise<MeResponse | null> {
-  return await queryClient.fetchQuery({
-    queryKey: ME_QUERY_KEY,
-    queryFn: async () => {
-      const res = await client.api.auth.me.$get();
-      if (res.status === 401 || res.status === 403) {
-        return null;
-      }
-      if (!res.ok) {
-        throw new Error('ユーザー情報の取得に失敗しました');
-      }
-      return meResponseSchema.parse(await res.json());
-    },
-  });
+  return await queryClient.fetchQuery(meQueryOptions());
 }
 
 /**

--- a/src/features/auth/queries.ts
+++ b/src/features/auth/queries.ts
@@ -28,11 +28,13 @@ export function useMe() {
       }
       return meResponseSchema.parse(await res.json());
     },
+    // 認証主体の取り違えを防ぐため、identity はグローバルの staleTime（60s）でマスクせず、マウント・フォーカスのたびに再検証する
+    staleTime: 0,
   });
 }
 
 /**
- * ログアウトする。成功後は認証状態キャッシュを無効化する。
+ * ログアウトする。成功後は認証済みの全キャッシュを破棄する。
  */
 export function useLogout() {
   const queryClient = useQueryClient();
@@ -44,6 +46,9 @@ export function useLogout() {
       }
     },
     onSuccess: () => {
+      // ログアウト時は認証済みの全キャッシュを破棄し、同一 QueryClient を再利用する
+      // 後続の別ユーザーセッションに前ユーザーのデータ（統計・勤務可否等）が残らないようにする
+      queryClient.clear();
       queryClient.setQueryData(ME_QUERY_KEY, null);
     },
   });

--- a/src/features/auth/queries.ts
+++ b/src/features/auth/queries.ts
@@ -1,4 +1,11 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  mutationOptions,
+  queryOptions,
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type QueryClient,
+} from '@tanstack/react-query';
 import { z } from 'zod';
 
 import { client } from '@/lib/rpc';
@@ -11,12 +18,9 @@ const apiErrorSchema = z.object({ message: z.string().optional() });
 /** 認証状態のクエリキー */
 export const ME_QUERY_KEY = ['auth', 'me'] as const;
 
-/**
- * 現在ログイン中の User を取得する（/me 相当）。
- * 401 の場合は未認証として `null` を返し、エラー扱いにしない。
- */
-export function useMe() {
-  return useQuery<MeResponse | null>({
+/** 本人確認クエリを、マウント・フォーカス・ルート遷移のたびに再検証する設定で返す。 */
+export function meQueryOptions() {
+  return queryOptions<MeResponse | null>({
     queryKey: ME_QUERY_KEY,
     queryFn: async () => {
       const res = await client.api.auth.me.$get();
@@ -28,8 +32,38 @@ export function useMe() {
       }
       return meResponseSchema.parse(await res.json());
     },
-    // 認証主体の取り違えを防ぐため、identity はグローバルの staleTime（60s）でマスクせず、マウント・フォーカスのたびに再検証する
+    // 認証主体の取り違えを防ぐため、本人確認はグローバルの staleTime（60s）でマスクしない
     staleTime: 0,
+  });
+}
+
+/**
+ * 現在ログイン中の User を取得する（/me 相当）。
+ * 401 の場合は未認証として `null` を返し、エラー扱いにしない。
+ */
+export function useMe() {
+  return useQuery(meQueryOptions());
+}
+
+/** 認証済みキャッシュを全て破棄し、同じ QueryClient を未認証状態へ切り替える。 */
+export function clearAuthenticatedCache(queryClient: QueryClient): void {
+  queryClient.clear();
+  queryClient.setQueryData(ME_QUERY_KEY, null);
+}
+
+/** ログアウト成功時に認証済みキャッシュを破棄する mutation 設定を返す。 */
+export function logoutMutationOptions(queryClient: QueryClient) {
+  return mutationOptions({
+    mutationFn: async () => {
+      const res = await client.api.auth.logout.$post();
+      if (!res.ok) {
+        throw new Error('ログアウトに失敗しました');
+      }
+    },
+    onSuccess: () => {
+      // 後続の別 User セッションに前 User の統計・勤務可否等を残さない
+      clearAuthenticatedCache(queryClient);
+    },
   });
 }
 
@@ -38,20 +72,7 @@ export function useMe() {
  */
 export function useLogout() {
   const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: async () => {
-      const res = await client.api.auth.logout.$post();
-      if (!res.ok) {
-        throw new Error('ログアウトに失敗しました');
-      }
-    },
-    onSuccess: () => {
-      // ログアウト時は認証済みの全キャッシュを破棄し、同一 QueryClient を再利用する
-      // 後続の別ユーザーセッションに前ユーザーのデータ（統計・勤務可否等）が残らないようにする
-      queryClient.clear();
-      queryClient.setQueryData(ME_QUERY_KEY, null);
-    },
-  });
+  return useMutation(logoutMutationOptions(queryClient));
 }
 
 /**

--- a/src/features/auth/route-policy.ts
+++ b/src/features/auth/route-policy.ts
@@ -1,0 +1,21 @@
+/** 未認証時にログインへ遷移するためのルート指定。 */
+export type UnauthenticatedRedirect = {
+  to: '/login';
+  search: { redirect: string };
+  replace: true;
+};
+
+/**
+ * 未認証で表示してよいルートかを判定し、保護ルートならログインへの遷移先を返す。
+ * @param pathname - 現在表示しているパス
+ */
+export function getUnauthenticatedRedirect(pathname: string): UnauthenticatedRedirect | null {
+  if (pathname === '/login') {
+    return null;
+  }
+  return {
+    to: '/login',
+    search: { redirect: pathname },
+    replace: true,
+  };
+}

--- a/src/features/auth/route-policy.ts
+++ b/src/features/auth/route-policy.ts
@@ -8,14 +8,18 @@ export type UnauthenticatedRedirect = {
 /**
  * 未認証で表示してよいルートかを判定し、保護ルートならログインへの遷移先を返す。
  * @param pathname - 現在表示しているパス
+ * @param redirectPath - 認証後に戻す現在地（クエリを含む）
  */
-export function getUnauthenticatedRedirect(pathname: string): UnauthenticatedRedirect | null {
+export function getUnauthenticatedRedirect(
+  pathname: string,
+  redirectPath = pathname,
+): UnauthenticatedRedirect | null {
   if (pathname === '/login') {
     return null;
   }
   return {
     to: '/login',
-    search: { redirect: pathname },
+    search: { redirect: redirectPath },
     replace: true,
   };
 }

--- a/src/features/availabilities/queries.ts
+++ b/src/features/availabilities/queries.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { z } from 'zod';
 
+import { useMe } from '@/features/auth/queries';
 import { client } from '@/lib/rpc';
 
 import {
@@ -12,10 +13,14 @@ import {
 
 const apiErrorSchema = z.object({ message: z.string().optional() });
 
-/** 本人の可用性申告クエリキー。月単位でキャッシュする。 */
+/** 本人の可用性申告クエリキー。認証主体・月単位でキャッシュする。 */
 export const MY_AVAILABILITIES_QUERY_KEY = ['availabilities', 'me'] as const;
 /** 管理者向け可用性一覧クエリキー。 */
 export const AVAILABILITIES_QUERY_KEY = ['availabilities'] as const;
+
+/** 本人の勤務可否クエリキーを認証主体 userId と対象月で隔離して組み立てる。 */
+export const myAvailabilitiesQueryKey = (userId: string, month: string) =>
+  [...MY_AVAILABILITIES_QUERY_KEY, userId, month] as const;
 
 /** 指定期間の全インストラクターの可用性を取得する（MANAGER 以上）。 */
 export function useAvailabilities(from: string, to: string) {
@@ -39,6 +44,7 @@ export function useAvailabilities(from: string, to: string) {
 
 /** 指定月の本人申告と編集不能な割当日を取得する。 */
 export function useMyAvailabilities(month: string, enabled = true) {
+  const userId = useMe().data?.id;
   const from = `${month}-01`;
   const nextMonth = new Date(`${from}T00:00:00.000Z`);
   nextMonth.setUTCMonth(nextMonth.getUTCMonth() + 1);
@@ -46,7 +52,7 @@ export function useMyAvailabilities(month: string, enabled = true) {
   const to = nextMonth.toISOString().slice(0, 10);
 
   return useQuery({
-    queryKey: [...MY_AVAILABILITIES_QUERY_KEY, month],
+    queryKey: myAvailabilitiesQueryKey(userId ?? '', month),
     queryFn: async () => {
       const res = await client.api.availabilities.me.$get({ query: { from, to } });
       if (!res.ok) {
@@ -59,7 +65,7 @@ export function useMyAvailabilities(month: string, enabled = true) {
       }
       return availabilityListResponseSchema.parse(await res.json());
     },
-    enabled,
+    enabled: enabled && !!userId,
   });
 }
 
@@ -80,6 +86,7 @@ export function useUpdateMyAvailabilities() {
       return z.object({ updatedCount: z.number() }).parse(await res.json());
     },
     onSuccess: () => {
+      // 共通プレフィックスで userId・月を含む本人可用性キャッシュも無効化する
       void queryClient.invalidateQueries({ queryKey: MY_AVAILABILITIES_QUERY_KEY });
     },
   });

--- a/src/features/certification-requirements/queries.ts
+++ b/src/features/certification-requirements/queries.ts
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { z } from 'zod';
 
 import type { DepartmentCode } from '@/features/departments/schema';
+import { MASTER_DATA_STALE_TIME } from '@/lib/query-client';
 import { client } from '@/lib/rpc';
 
 import {
@@ -23,6 +24,7 @@ export function useCertificationRequirements(
   return useQuery<CertificationRequirement[]>({
     queryKey: [...CERTIFICATION_REQUIREMENTS_QUERY_KEY, departmentCode, shiftTypeId],
     enabled: shiftTypeId !== null,
+    staleTime: MASTER_DATA_STALE_TIME,
     queryFn: async () => {
       if (!shiftTypeId) throw new Error('シフト種別が選択されていません');
       const res = await client.api['certification-requirements'][':departmentCode'][

--- a/src/features/certifications/queries.ts
+++ b/src/features/certifications/queries.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { z } from 'zod';
 
+import { MASTER_DATA_STALE_TIME } from '@/lib/query-client';
 import { client } from '@/lib/rpc';
 
 import {
@@ -25,6 +26,7 @@ export const CERTIFICATIONS_QUERY_KEY = ['certifications'] as const;
 export function useCertifications(activeOnly = true, departmentCode?: string) {
   return useQuery<Certification[]>({
     queryKey: [...CERTIFICATIONS_QUERY_KEY, { activeOnly, departmentCode }],
+    staleTime: MASTER_DATA_STALE_TIME,
     queryFn: async () => {
       const query: Record<string, string> = {};
       if (!activeOnly) query['active'] = 'false';
@@ -46,6 +48,7 @@ export function useCertifications(activeOnly = true, departmentCode?: string) {
 export function useCertification(id: string) {
   return useQuery<Certification>({
     queryKey: [...CERTIFICATIONS_QUERY_KEY, id],
+    staleTime: MASTER_DATA_STALE_TIME,
     queryFn: async () => {
       const res = await client.api.certifications[':id'].$get({ param: { id } });
       if (!res.ok) {

--- a/src/features/department-shift-types/queries.ts
+++ b/src/features/department-shift-types/queries.ts
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { z } from 'zod';
 
 import type { DepartmentCode } from '@/features/departments/schema';
+import { MASTER_DATA_STALE_TIME } from '@/lib/query-client';
 import { client } from '@/lib/rpc';
 
 import {
@@ -21,6 +22,7 @@ const apiErrorSchema = z.object({ message: z.string().optional() });
 export function useDepartmentShiftTypes(departmentCode: DepartmentCode) {
   return useQuery<DepartmentShiftType[]>({
     queryKey: [...DEPARTMENT_SHIFT_TYPES_QUERY_KEY, departmentCode],
+    staleTime: MASTER_DATA_STALE_TIME,
     queryFn: async () => {
       const res = await client.api['department-shift-types'][':departmentCode'].$get({
         param: { departmentCode },

--- a/src/features/shift-types/queries.ts
+++ b/src/features/shift-types/queries.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { z } from 'zod';
 
+import { MASTER_DATA_STALE_TIME } from '@/lib/query-client';
 import { client } from '@/lib/rpc';
 
 import {
@@ -25,6 +26,7 @@ export const SHIFT_TYPES_QUERY_KEY = ['shift-types'] as const;
 export function useShiftTypes(activeOnly = true) {
   return useQuery<ShiftTypeListItem[]>({
     queryKey: [...SHIFT_TYPES_QUERY_KEY, { activeOnly }],
+    staleTime: MASTER_DATA_STALE_TIME,
     queryFn: async () => {
       const res = await client.api['shift-types'].$get({
         query: activeOnly ? {} : { active: 'false' },
@@ -44,6 +46,7 @@ export function useShiftTypes(activeOnly = true) {
 export function useShiftType(id: string) {
   return useQuery<ShiftType>({
     queryKey: [...SHIFT_TYPES_QUERY_KEY, id],
+    staleTime: MASTER_DATA_STALE_TIME,
     queryFn: async () => {
       const res = await client.api['shift-types'][':id'].$get({ param: { id } });
       if (!res.ok) {

--- a/src/features/shifts/queries.ts
+++ b/src/features/shifts/queries.ts
@@ -1,4 +1,10 @@
-import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  queryOptions,
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 import { z } from 'zod';
 
 import { useMe } from '@/features/auth/queries';
@@ -277,7 +283,15 @@ export function useMySeasonStats() {
   const me = useMe();
   const userId = me.data?.id;
 
-  return useQuery<SeasonStatsResponse>({
+  return useQuery(mySeasonStatsQueryOptions(userId));
+}
+
+/**
+ * ダッシュボード「今シーズン」集計の query 設定を認証主体ごとに返す。
+ * @param userId - 現在ログイン中の User ID。未認証時は取得を無効化する
+ */
+export function mySeasonStatsQueryOptions(userId: string | undefined) {
+  return queryOptions<SeasonStatsResponse>({
     queryKey: seasonStatsQueryKey(userId ?? ''),
     queryFn: async () => {
       const res = await client.api.shifts.me['season-stats'].$get();

--- a/src/features/shifts/queries.ts
+++ b/src/features/shifts/queries.ts
@@ -1,6 +1,8 @@
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { z } from 'zod';
 
+import { useMe } from '@/features/auth/queries';
+import { SEASON_STATS_CACHE_TIME } from '@/lib/query-client';
 import { client } from '@/lib/rpc';
 
 import {
@@ -37,6 +39,9 @@ export const SHIFTS_QUERY_KEY = ['shifts'] as const;
  * `v2` は昨季同時点の値を持たない旧レスポンスを永続キャッシュから再利用しないための世代番号。
  */
 export const SEASON_STATS_QUERY_KEY = [...SHIFTS_QUERY_KEY, 'me', 'season-stats', 'v2'] as const;
+
+/** season-stats のクエリキーを認証主体 userId で隔離して組み立てる（クロスユーザーのキャッシュ再利用を防ぐ）。 */
+export const seasonStatsQueryKey = (userId: string) => [...SEASON_STATS_QUERY_KEY, userId] as const;
 
 /** アジェンダ取得パラメータ */
 export type ShiftAgendaParams = {
@@ -265,10 +270,15 @@ export function useShiftAssignmentEditor(params: Partial<ShiftEditDataParams>) {
  * ダッシュボード「今シーズン」セクション向けの集計を取得する（Issue #203）。
  * ログイン User が Instructor 未連携の場合はサーバーが 404 を返す前提のため、
  * 呼び出し元（ダッシュボード）は instructorId が確定しているときだけ描画すること。
+ * userId でキャッシュを隔離し、12h の staleTime/gcTime でセッション中の重い再計算を抑える。
+ * メモリキャッシュのため、リロード時は最新を再取得する。
  */
 export function useMySeasonStats() {
+  const me = useMe();
+  const userId = me.data?.id;
+
   return useQuery<SeasonStatsResponse>({
-    queryKey: SEASON_STATS_QUERY_KEY,
+    queryKey: seasonStatsQueryKey(userId ?? ''),
     queryFn: async () => {
       const res = await client.api.shifts.me['season-stats'].$get();
       if (!res.ok) {
@@ -277,6 +287,9 @@ export function useMySeasonStats() {
       }
       return seasonStatsResponseSchema.parse(await res.json());
     },
+    enabled: !!userId,
+    staleTime: SEASON_STATS_CACHE_TIME,
+    gcTime: SEASON_STATS_CACHE_TIME,
   });
 }
 

--- a/src/lib/query-client.ts
+++ b/src/lib/query-client.ts
@@ -1,11 +1,17 @@
 import { QueryClient } from '@tanstack/react-query';
 
+/** マスタ系（管理者 mutation でのみ変化するデータ）向けの staleTime。時間ベース再取得を抑え、mutation の invalidate に古さの解消を委ねる。 */
+export const MASTER_DATA_STALE_TIME = 5 * 60 * 1_000;
+
+/** ユーザー固有かつ計算コストの高い season-stats 集計向けの staleTime / gcTime。『前日時点』の古さを許容し、セッション中の重い再計算を抑える。 */
+export const SEASON_STATS_CACHE_TIME = 12 * 60 * 60 * 1_000;
+
 /** アプリ全体で共有する TanStack Query クライアント。 */
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      // マウント直後 30 秒はキャッシュを新鮮とみなし、不要な再フェッチを抑制する
-      staleTime: 30_000,
+      // マウント直後 60 秒はキャッシュを新鮮とみなし、不要な再フェッチを抑制する
+      staleTime: 60_000,
       // ネットワーク障害時の連続リトライによる遅延を避けるため 1 回に制限する
       retry: 1,
     },

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,14 +1,7 @@
-import { AppShell, Burger, Group, Text } from '@mantine/core';
-import { useDisclosure } from '@mantine/hooks';
 import type { QueryClient } from '@tanstack/react-query';
-import { createRootRouteWithContext, Link, Outlet } from '@tanstack/react-router';
+import { createRootRouteWithContext } from '@tanstack/react-router';
 
-import { useMe } from '@/features/auth/queries';
-
-import { MemberInstructorLinkPrompt } from './components/MemberInstructorLinkPrompt';
-import { MobileNavigation } from './components/MobileNavigation';
-import { NavigationMenu } from './components/NavigationMenu';
-import { UserMenu } from './components/UserMenu';
+import { RootLayout } from './components/RootLayout';
 
 /** ルーターコンテキスト。ガードのデータ取得に QueryClient を共有する（ADR 0002） */
 export type RouterContext = {
@@ -19,57 +12,3 @@ export type RouterContext = {
 export const Route = createRootRouteWithContext<RouterContext>()({
   component: RootLayout,
 });
-
-function RootLayout() {
-  const { data: user, isLoading } = useMe();
-  const [desktopNavbarOpened, { toggle: toggleDesktopNavbar }] = useDisclosure(true);
-
-  // 未認証（ログイン画面等）は AppShell なしで素通しする
-  if (isLoading || !user) {
-    return <Outlet />;
-  }
-
-  return (
-    <AppShell
-      header={{ height: 60 }}
-      navbar={{
-        width: 260,
-        breakpoint: 'sm',
-        collapsed: { mobile: true, desktop: !desktopNavbarOpened },
-      }}
-      padding="md"
-    >
-      <AppShell.Header>
-        <Group h="100%" px={{ base: 'xs', sm: 'md' }} justify="space-between" wrap="nowrap">
-          <Group gap="xs" wrap="nowrap">
-            <Burger
-              visibleFrom="sm"
-              opened={desktopNavbarOpened}
-              onClick={toggleDesktopNavbar}
-              aria-label={desktopNavbarOpened ? 'サイドバーを閉じる' : 'サイドバーを開く'}
-              size="sm"
-            />
-            <Text component={Link} to="/" fw={700} size="lg" c="blue" td="none">
-              Fuyugyō
-            </Text>
-          </Group>
-          <Group gap="xs" wrap="nowrap">
-            <MobileNavigation user={user} />
-            <Group visibleFrom="sm" gap={0} wrap="nowrap">
-              <UserMenu user={user} />
-            </Group>
-          </Group>
-        </Group>
-      </AppShell.Header>
-      <AppShell.Navbar p="sm">
-        <AppShell.Section grow>
-          <NavigationMenu user={user} />
-        </AppShell.Section>
-      </AppShell.Navbar>
-      <AppShell.Main>
-        <MemberInstructorLinkPrompt user={user} />
-        <Outlet />
-      </AppShell.Main>
-    </AppShell>
-  );
-}

--- a/src/routes/components/RootLayout.tsx
+++ b/src/routes/components/RootLayout.tsx
@@ -20,7 +20,10 @@ export function RootLayout() {
     return <Outlet />;
   }
   if (!user) {
-    const redirect = getUnauthenticatedRedirect(location.pathname);
+    const redirect = getUnauthenticatedRedirect(
+      location.pathname,
+      location.pathname + location.searchStr,
+    );
     return redirect ? <Navigate {...redirect} /> : <Outlet />;
   }
 

--- a/src/routes/components/RootLayout.tsx
+++ b/src/routes/components/RootLayout.tsx
@@ -1,0 +1,70 @@
+import { AppShell, Burger, Group, Text } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { Link, Navigate, Outlet, useLocation } from '@tanstack/react-router';
+
+import { useMe } from '@/features/auth/queries';
+import { getUnauthenticatedRedirect } from '@/features/auth/route-policy';
+
+import { MemberInstructorLinkPrompt } from './MemberInstructorLinkPrompt';
+import { MobileNavigation } from './MobileNavigation';
+import { NavigationMenu } from './NavigationMenu';
+import { UserMenu } from './UserMenu';
+
+/** 認証状態に応じてログイン画面または認証済みアプリシェルを描画する。 */
+export function RootLayout() {
+  const { data: user, isLoading } = useMe();
+  const location = useLocation();
+  const [desktopNavbarOpened, { toggle: toggleDesktopNavbar }] = useDisclosure(true);
+
+  if (isLoading) {
+    return <Outlet />;
+  }
+  if (!user) {
+    const redirect = getUnauthenticatedRedirect(location.pathname);
+    return redirect ? <Navigate {...redirect} /> : <Outlet />;
+  }
+
+  return (
+    <AppShell
+      header={{ height: 60 }}
+      navbar={{
+        width: 260,
+        breakpoint: 'sm',
+        collapsed: { mobile: true, desktop: !desktopNavbarOpened },
+      }}
+      padding="md"
+    >
+      <AppShell.Header>
+        <Group h="100%" px={{ base: 'xs', sm: 'md' }} justify="space-between" wrap="nowrap">
+          <Group gap="xs" wrap="nowrap">
+            <Burger
+              visibleFrom="sm"
+              opened={desktopNavbarOpened}
+              onClick={toggleDesktopNavbar}
+              aria-label={desktopNavbarOpened ? 'サイドバーを閉じる' : 'サイドバーを開く'}
+              size="sm"
+            />
+            <Text component={Link} to="/" fw={700} size="lg" c="blue" td="none">
+              Fuyugyō
+            </Text>
+          </Group>
+          <Group gap="xs" wrap="nowrap">
+            <MobileNavigation user={user} />
+            <Group visibleFrom="sm" gap={0} wrap="nowrap">
+              <UserMenu user={user} />
+            </Group>
+          </Group>
+        </Group>
+      </AppShell.Header>
+      <AppShell.Navbar p="sm">
+        <AppShell.Section grow>
+          <NavigationMenu user={user} />
+        </AppShell.Section>
+      </AppShell.Navbar>
+      <AppShell.Main>
+        <MemberInstructorLinkPrompt user={user} />
+        <Outlet />
+      </AppShell.Main>
+    </AppShell>
+  );
+}

--- a/test/auth-client-session.test.ts
+++ b/test/auth-client-session.test.ts
@@ -96,6 +96,14 @@ describe('未認証時のルーティング', () => {
     });
   });
 
+  it('保護画面のクエリをログイン後の戻り先に引き継ぐ', () => {
+    expect(getUnauthenticatedRedirect('/shifts', '/shifts?date=2026-01')).toEqual({
+      to: '/login',
+      search: { redirect: '/shifts?date=2026-01' },
+      replace: true,
+    });
+  });
+
   it('ログイン画面ではリダイレクトしない', () => {
     expect(getUnauthenticatedRedirect('/login')).toBeNull();
   });

--- a/test/auth-client-session.test.ts
+++ b/test/auth-client-session.test.ts
@@ -1,0 +1,140 @@
+import { createElement } from 'react';
+import { renderToString } from 'react-dom/server';
+
+import {
+  focusManager,
+  MutationObserver,
+  QueryClient,
+  QueryClientProvider,
+  QueryObserver,
+} from '@tanstack/react-query';
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from '@tanstack/react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { logoutMutationOptions, ME_QUERY_KEY, meQueryOptions } from '../src/features/auth/queries';
+import { getUnauthenticatedRedirect } from '../src/features/auth/route-policy';
+import type { MeResponse } from '../src/features/auth/schema';
+import { mySeasonStatsQueryOptions, seasonStatsQueryKey } from '../src/features/shifts/queries';
+import { RootLayout } from '../src/routes/components/RootLayout';
+
+const userA: MeResponse = {
+  id: 'user-a',
+  lineUserId: 'line-user-a',
+  displayName: 'User A',
+  pictureUrl: null,
+  role: 'MEMBER',
+  instructorId: 'instructor-a',
+  isActive: true,
+};
+
+afterEach(() => {
+  focusManager.setFocused(undefined);
+  vi.unstubAllGlobals();
+});
+
+describe('認証済みクライアントセッション', () => {
+  it('window focus 時に本人を再検証して未認証状態へ更新する', async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(Response.json(userA))
+      .mockResolvedValueOnce(new Response(null, { status: 401 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const queryClient = new QueryClient();
+    const observer = new QueryObserver(queryClient, meQueryOptions());
+    const unsubscribe = observer.subscribe(() => undefined);
+    queryClient.mount();
+
+    await vi.waitFor(() => expect(queryClient.getQueryData(ME_QUERY_KEY)).toEqual(userA));
+    focusManager.setFocused(false);
+    focusManager.setFocused(true);
+    await vi.waitFor(() => expect(queryClient.getQueryData(ME_QUERY_KEY)).toBeNull());
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    unsubscribe();
+    queryClient.unmount();
+  });
+
+  it('logout mutation 成功時に旧 User のキャッシュを破棄して未認証状態にする', async () => {
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>().mockResolvedValue(Response.json({ ok: true })));
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(seasonStatsQueryKey('user-a'), { owner: 'user-a' });
+    queryClient.setQueryData(['shift-types'], [{ id: 'shift-type-1' }]);
+    const observer = new MutationObserver(queryClient, logoutMutationOptions(queryClient));
+
+    await observer.mutate();
+
+    expect(queryClient.getQueryData(seasonStatsQueryKey('user-a'))).toBeUndefined();
+    expect(queryClient.getQueryData(['shift-types'])).toBeUndefined();
+    expect(queryClient.getQueryData(ME_QUERY_KEY)).toBeNull();
+  });
+
+  it('認証主体が変わると統計 observer が旧 User の値を表示しない', () => {
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(seasonStatsQueryKey('user-a'), { owner: 'user-a' });
+    const observer = new QueryObserver(queryClient, mySeasonStatsQueryOptions('user-a'));
+
+    expect(observer.getCurrentResult().data).toEqual({ owner: 'user-a' });
+    observer.setOptions(mySeasonStatsQueryOptions('user-b'));
+
+    expect(observer.getCurrentResult().data).toBeUndefined();
+  });
+});
+
+describe('未認証時のルーティング', () => {
+  it('保護画面をログインへ置き換えて元のパスを引き継ぐ', () => {
+    expect(getUnauthenticatedRedirect('/shifts/manage')).toEqual({
+      to: '/login',
+      search: { redirect: '/shifts/manage' },
+      replace: true,
+    });
+  });
+
+  it('ログイン画面ではリダイレクトしない', () => {
+    expect(getUnauthenticatedRedirect('/login')).toBeNull();
+  });
+
+  it('未認証になった保護画面の内容を描画しない', async () => {
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(ME_QUERY_KEY, null);
+    const rootRoute = createRootRoute({
+      component: RootLayout,
+    });
+    const layoutRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      id: 'layout',
+      component: Outlet,
+    });
+    const protectedRoute = createRoute({
+      getParentRoute: () => layoutRoute,
+      path: '/protected',
+      component: () => createElement('p', null, '保護画面'),
+    });
+    const loginRoute = createRoute({
+      getParentRoute: () => layoutRoute,
+      path: '/login',
+      component: () => createElement('p', null, 'ログイン画面'),
+    });
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([layoutRoute.addChildren([protectedRoute, loginRoute])]),
+      history: createMemoryHistory({ initialEntries: ['/protected'] }),
+    });
+    await router.load();
+
+    const html = renderToString(
+      createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        createElement(RouterProvider, { router }),
+      ),
+    );
+
+    expect(html).not.toContain('保護画面');
+  });
+});

--- a/test/my-availabilities-query.test.ts
+++ b/test/my-availabilities-query.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MY_AVAILABILITIES_QUERY_KEY,
+  myAvailabilitiesQueryKey,
+} from '../src/features/availabilities/queries';
+
+describe('myAvailabilitiesQueryKey', () => {
+  it('認証主体ごとに異なるクエリキーを組み立てる', () => {
+    expect(myAvailabilitiesQueryKey('userA', '2026-01')).not.toEqual(
+      myAvailabilitiesQueryKey('userB', '2026-01'),
+    );
+  });
+
+  it('同じ認証主体でも対象月ごとに異なるクエリキーを組み立てる', () => {
+    expect(myAvailabilitiesQueryKey('userA', '2026-01')).not.toEqual(
+      myAvailabilitiesQueryKey('userA', '2026-02'),
+    );
+  });
+
+  it('本人可用性キーをプレフィックスとして維持する', () => {
+    expect(myAvailabilitiesQueryKey('userA', '2026-01')).toEqual([
+      ...MY_AVAILABILITIES_QUERY_KEY,
+      'userA',
+      '2026-01',
+    ]);
+  });
+});

--- a/test/root-layout.test.ts
+++ b/test/root-layout.test.ts
@@ -1,0 +1,41 @@
+import { createElement } from 'react';
+import { renderToString } from 'react-dom/server';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, expect, it, vi } from 'vitest';
+
+import { RootLayout } from '../src/routes/components/RootLayout';
+
+const routerMock = vi.hoisted(() => ({
+  navigateProps: undefined as unknown,
+}));
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@tanstack/react-router')>();
+  return {
+    ...original,
+    Navigate: (props: unknown) => {
+      routerMock.navigateProps = props;
+      return null;
+    },
+    useLocation: () => ({ pathname: '/shifts', searchStr: '?date=2026-01' }),
+  };
+});
+
+vi.mock('../src/features/auth/queries', () => ({
+  useMe: () => ({ data: null, isLoading: false }),
+}));
+
+describe('RootLayout', () => {
+  it('未認証時は現在地のクエリを含めてログインへ遷移する', () => {
+    renderToString(
+      createElement(QueryClientProvider, { client: new QueryClient() }, createElement(RootLayout)),
+    );
+
+    expect(routerMock.navigateProps).toEqual({
+      to: '/login',
+      search: { redirect: '/shifts?date=2026-01' },
+      replace: true,
+    });
+  });
+});

--- a/test/season-stats-query.test.ts
+++ b/test/season-stats-query.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { SEASON_STATS_QUERY_KEY } from '../src/features/shifts/queries';
+import { SEASON_STATS_QUERY_KEY, seasonStatsQueryKey } from '../src/features/shifts/queries';
 import { seasonStatsResponseSchema } from '../src/features/shifts/schema';
 
 describe('SEASON_STATS_QUERY_KEY', () => {
@@ -24,5 +24,15 @@ describe('SEASON_STATS_QUERY_KEY', () => {
     };
 
     expect(seasonStatsResponseSchema.safeParse(legacyResponse).success).toBe(false);
+  });
+});
+
+describe('seasonStatsQueryKey', () => {
+  it('認証主体ごとに異なるクエリキーを組み立てる', () => {
+    expect(seasonStatsQueryKey('userA')).not.toEqual(seasonStatsQueryKey('userB'));
+  });
+
+  it('既存の season-stats キーをプレフィックスとして維持する', () => {
+    expect(seasonStatsQueryKey('userA')).toEqual([...SEASON_STATS_QUERY_KEY, 'userA']);
   });
 });


### PR DESCRIPTION
# プルリクエストテンプレート

## 概要

issue #210 の staleTime 見直しとして、グローバル既定値の引き上げとクエリごとの個別最適化を実施。長期キャッシュ化に伴うクロスユーザー混在リスクに対応するため、ユーザー固有クエリのキャッシュ隔離も併せて行った。対応中に見つかった「セッション期限切れ時に保護画面が残る」不具合も同一PRで修正。

## やったこと

- グローバル default staleTime を 30s→60s に引き上げ、マスタ系クエリ（shift-types / department-shift-types / certifications / certification-requirements）に staleTime 5分、season-stats に staleTime/gcTime 12h を付与。併せて season-stats・availabilities-me のクエリキーに userId を含めてキャッシュを隔離し、ログアウト時に全キャッシュを破棄、useMe を常時再検証（staleTime 0）に変更
- 期限切れセッションで保護画面が残る不具合を修正。認証再検証・ルーティング・キャッシュ破棄を連携させ、結合テストで固定

## レビューポイント

- staleTime の各設定値（60s / 5分 / 12h）の妥当性
- ユーザー固有キャッシュの隔離・破棄ロジックが、ログアウト時とセッション期限切れ時の両方で正しく機能するか

## 備考

- issue #210 のスコープ（現状値のベースライン記録）を超えて、staleTime の個別最適化まで前倒しで実施
- Workers Cache（ADR 0013）は引き続き見送り方針を維持
