### PR TITLE
✨ Add userId-based rate limiting for read APIs

### DIFF
--- a/src/features/shifts/api.ts
+++ b/src/features/shifts/api.ts
@@ -37,6 +37,7 @@ import {
   users,
 } from '@/server/db/schema';
 import { requireAuth, requireRole, type AuthVariables } from '@/server/middleware/auth';
+import { readRateLimit } from '@/server/middleware/rate-limit';
 import type { Env } from '@/server/types';
 
 import { groupShiftsByWorkingDay, summarizeShifts } from './aggregators';
@@ -1047,7 +1048,7 @@ export const shiftsRoute = new Hono<{
    * アジェンダビュー: 起点日から未来/過去方向へ、Shift が 1 件以上ある稼働日だけを返す。
    * 休校日は日付行自体を返さず、各稼働日の Shift は部門 × シフト種別でまとめて返す。
    */
-  .get('/agenda', requireAuth, async (c) => {
+  .get('/agenda', requireAuth, readRateLimit(), async (c) => {
     const cursor = c.req.query('cursor');
     const directionQuery = c.req.query('direction') ?? 'future';
     const departmentCode = c.req.query('departmentCode');
@@ -1142,7 +1143,7 @@ export const shiftsRoute = new Hono<{
    * 休校日（シフトが0件の日）は要素を持たないだけで、400 にはしない。
    * ダッシュボードの「今日・明日の出勤状況」「同じ日に勤務する同僚一覧」で共有する。
    */
-  .get('/attendance', requireAuth, async (c) => {
+  .get('/attendance', requireAuth, readRateLimit(), async (c) => {
     const datesQuery = c.req.query('dates');
     if (!datesQuery) {
       throw new HTTPException(400, { message: 'dates を指定してください' });

--- a/src/server/middleware/rate-limit.ts
+++ b/src/server/middleware/rate-limit.ts
@@ -1,6 +1,7 @@
 import { createMiddleware } from 'hono/factory';
 import { HTTPException } from 'hono/http-exception';
 
+import { type AuthVariables } from '@/server/middleware/auth';
 import type { Env } from '@/server/types';
 
 /**
@@ -29,6 +30,28 @@ export function rateLimit(bucket: string) {
     });
 
     if (!success) {
+      throw new HTTPException(429, {
+        message: 'Too many requests. Please try again later.',
+      });
+    }
+
+    await next();
+  });
+}
+
+/**
+ * 認証済み高コスト read 用の Rate Limit。requireAuth の後段で userId をキーにレート制限する（issue #214）。
+ */
+export function readRateLimit() {
+  return createMiddleware<{ Bindings: Env; Variables: AuthVariables }>(async (c, next) => {
+    const { userId } = c.get('user');
+    const key = `read:${userId}`;
+    const { success } = await c.env.READ_RATE_LIMITER.limit({ key });
+
+    if (!success) {
+      console.warn(
+        JSON.stringify({ event: 'rate_limit_exceeded', limiter: 'read', key, path: c.req.path }),
+      );
       throw new HTTPException(429, {
         message: 'Too many requests. Please try again later.',
       });

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -23,4 +23,6 @@ export type Env = {
   APP_URL: string;
   /** 認証系エンドポイント用の CF ネイティブ Rate Limiter（ADR 0004） */
   AUTH_RATE_LIMITER: RateLimit;
+  /** 認証済み高コスト read 用の CF ネイティブ Rate Limiter（userId キー、issue #214） */
+  READ_RATE_LIMITER: RateLimit;
 };

--- a/test/env.d.ts
+++ b/test/env.d.ts
@@ -13,6 +13,7 @@ declare global {
       LINE_CHANNEL_SECRET: string;
       APP_URL: string;
       AUTH_RATE_LIMITER: import('@cloudflare/workers-types').RateLimit;
+      READ_RATE_LIMITER: import('@cloudflare/workers-types').RateLimit;
       /** vitest.config.ts の miniflare バインディングから渡されるマイグレーション一覧 */
       TEST_MIGRATIONS: D1Migration[];
     }

--- a/test/shift-view.integration.test.ts
+++ b/test/shift-view.integration.test.ts
@@ -33,6 +33,18 @@ function envWith(overrides: Partial<Env>): Env {
   return { ...(env as unknown as Env), ...overrides };
 }
 
+/** テスト中に件数を数える擬似 Rate Limiter。CF ネイティブ binding はローカルで決定論的に動かせないため注入する */
+function makeRateLimiter(limit: number) {
+  const counts = new Map<string, number>();
+  return {
+    limit: async ({ key }: { key: string }) => {
+      const next = (counts.get(key) ?? 0) + 1;
+      counts.set(key, next);
+      return { success: next <= limit };
+    },
+  };
+}
+
 function authHeader(token: string): RequestInit {
   return { headers: { cookie: `auth-token=${token}` } };
 }
@@ -600,5 +612,45 @@ describe('GET /api/shifts/attendance', () => {
   it('未認証は 401 を返す', async () => {
     const res = await app.request('/api/shifts/attendance?dates=2026-01-10', {}, envWith({}));
     expect(res.status).toBe(401);
+  });
+});
+
+// ─── 認証済み高コスト read の Rate Limit ─────────────────────────────────────
+
+describe('認証済み高コスト read の Rate Limit', () => {
+  it('同一ユーザーが上限を超えて agenda を連続で取得すると 429 を返す', async () => {
+    const token = await seedToken('MEMBER');
+    const reqEnv = envWith({ READ_RATE_LIMITER: makeRateLimiter(2) });
+    const path = '/api/shifts/agenda?cursor=2026-01-10&direction=future';
+
+    const first = await app.request(path, authHeader(token), reqEnv);
+    const second = await app.request(path, authHeader(token), reqEnv);
+    const third = await app.request(path, authHeader(token), reqEnv);
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(third.status).toBe(429);
+  });
+
+  it('ユーザーごとに別の上限を使う', async () => {
+    const tokenA = await seedToken('MEMBER');
+    const tokenB = await seedToken('MEMBER');
+    const reqEnv = envWith({ READ_RATE_LIMITER: makeRateLimiter(1) });
+    const path = '/api/shifts/agenda?cursor=2026-01-10&direction=future';
+
+    const firstForA = await app.request(path, authHeader(tokenA), reqEnv);
+    const firstForB = await app.request(path, authHeader(tokenB), reqEnv);
+
+    expect(firstForA.status).toBe(200);
+    expect(firstForB.status).toBe(200);
+  });
+
+  it('対象外の calendar は read limiter を参照しない', async () => {
+    const token = await seedToken('MEMBER');
+    const reqEnv = envWith({ READ_RATE_LIMITER: makeRateLimiter(0) });
+
+    const res = await app.request('/api/shifts/calendar?month=2026-01', authHeader(token), reqEnv);
+
+    expect(res.status).toBe(200);
   });
 });

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -27,11 +27,15 @@ LINE_CHANNEL_ID = "0000000000"
 
 # 認証系エンドポイント用の CF ネイティブ Rate Limiting バインディング（ADR 0004）。
 # 未認証の攻撃面（login/callback/招待検証）のみに適用する。60 秒あたり 20 リクエストまで。
-[[unsafe.bindings]]
+[[ratelimits]]
 name = "AUTH_RATE_LIMITER"
-type = "ratelimit"
 namespace_id = "1001"
 simple = { limit = 20, period = 60 }
+
+[[ratelimits]]
+name = "READ_RATE_LIMITER"
+namespace_id = "1002"
+simple = { limit = 60, period = 60 }
 
 [observability]
 enabled = true


### PR DESCRIPTION
## 概要

- 認証済みの高コスト read API（`/agenda`・`/attendance`）に、JWTの安定したユーザーIDをキーとする専用 Rate Limiting を導入（#214）
- 共有回線での正規利用者同士の相互429を避けるため、IPではなくuserId単位で制限する

## やったこと

- `readRateLimit` ミドルウェアを追加し、userIdをキーに `READ_RATE_LIMITER` で制限（`src/server/middleware/rate-limit.ts`）
- `/agenda`・`/attendance` に `requireAuth` の後段として `readRateLimit()` を適用（`src/features/shifts/api.ts`）
- `Env` に `READ_RATE_LIMITER` バインディングを追加（`src/server/types.ts`, `test/env.d.ts`）
- `wrangler.toml` の Rate Limit binding を `unsafe.bindings` から現行の `[[ratelimits]]` 形式へ移行し、`READ_RATE_LIMITER`（60req/60s）を追加。認証用 `AUTH_RATE_LIMITER` とは namespace・閾値を分離
- 429応答・ユーザー別上限・対象外エンドポイント（calendar）への非適用を検証する統合テストを追加

## レビューポイント

- read用の閾値（60req/60s）が妥当か
- issue #214 で対象に挙がっているカレンダー・自動割当コンテキスト・月次一括更新への適用は本PRの範囲外としているが、この分割方針でよいか

## 備考

- issue #214 のAcceptance Criteriaにある ADR 0004・ADR 0013 の記述更新は本PRでは未実施
