### PR TITLE
📱 Improve mobile layout across list views

### DIFF
--- a/src/components/ClickableTr.module.css
+++ b/src/components/ClickableTr.module.css
@@ -1,3 +1,7 @@
 .row {
   cursor: pointer;
 }
+
+.inactive td {
+  background-color: light-dark(var(--mantine-color-gray-1), var(--mantine-color-dark-5));
+}

--- a/src/components/ClickableTr.tsx
+++ b/src/components/ClickableTr.tsx
@@ -6,7 +6,13 @@ import classes from './ClickableTr.module.css';
  * クリックで編集導線を開く一覧テーブルの行。
  * Table.Tr の薄いラッパーで、カーソルを pointer にするスタイルを内蔵する。
  */
-export function ClickableTr({ className, ...props }: TableTrProps) {
-  const rowClassName = className ? `${classes.row} ${className}` : classes.row;
+export function ClickableTr({
+  className,
+  inactive = false,
+  ...props
+}: TableTrProps & { inactive?: boolean }) {
+  const rowClassName = [classes.row, inactive && classes.inactive, className]
+    .filter(Boolean)
+    .join(' ');
   return <Table.Tr className={rowClassName} {...props} />;
 }

--- a/src/components/MobileListItem.module.css
+++ b/src/components/MobileListItem.module.css
@@ -1,3 +1,11 @@
+.row {
+  padding: var(--mantine-spacing-sm);
+}
+
+.row + .row {
+  border-top: 1px solid var(--mantine-color-default-border);
+}
+
 .inactive {
   background-color: light-dark(var(--mantine-color-gray-1), var(--mantine-color-dark-5));
 }

--- a/src/components/MobileListItem.module.css
+++ b/src/components/MobileListItem.module.css
@@ -1,0 +1,3 @@
+.inactive {
+  background-color: light-dark(var(--mantine-color-gray-1), var(--mantine-color-dark-5));
+}

--- a/src/components/UnsavedChangesBar.module.css
+++ b/src/components/UnsavedChangesBar.module.css
@@ -8,7 +8,16 @@
   backdrop-filter: blur(8px);
 }
 
+/* 固定バーの背後にコンテンツ末尾が隠れないよう、表示中だけ AppShell にスクロール余白を確保する。 */
+:global(.mantine-AppShell-main):has(.bar) {
+  padding-bottom: calc(100px + env(safe-area-inset-bottom));
+}
+
 @media (max-width: 48em) {
+  :global(.mantine-AppShell-main):has(.bar) {
+    padding-bottom: calc(140px + env(safe-area-inset-bottom));
+  }
+
   .bar {
     inset-inline-end: 10px;
     bottom: 10px;

--- a/src/features/certifications/components/CertificationList.tsx
+++ b/src/features/certifications/components/CertificationList.tsx
@@ -4,7 +4,6 @@ import { Group, Paper, Stack, Table, Text } from '@mantine/core';
 import { IconCertificate, IconPlus } from '@tabler/icons-react';
 
 import { ErrorAlert } from '@/components/AppAlert';
-import { AppBadge } from '@/components/AppBadge';
 import { AppButton } from '@/components/AppButton';
 import { AppTable } from '@/components/AppTable';
 import { ClickableTr } from '@/components/ClickableTr';
@@ -106,7 +105,6 @@ export function CertificationList() {
                   <Table.Th>資格名</Table.Th>
                   <Table.Th>部門</Table.Th>
                   <Table.Th>発行団体</Table.Th>
-                  <Table.Th w={100}>状態</Table.Th>
                   <Table.Th w={72} />
                 </Table.Tr>
               </Table.Thead>
@@ -147,10 +145,8 @@ type CertificationRowProps = {
 
 /** 資格一覧の1行。クリックで編集 Drawer を開く。 */
 function CertificationRow({ certification, onEdit }: CertificationRowProps) {
-  const isActive = certification.isActive;
-
   return (
-    <ClickableTr onClick={onEdit}>
+    <ClickableTr inactive={!certification.isActive} onClick={onEdit}>
       <Table.Td>
         <Text fw={500} size="sm">
           {certification.name}
@@ -164,9 +160,6 @@ function CertificationRow({ certification, onEdit }: CertificationRowProps) {
       </Table.Td>
       <Table.Td>
         <Text size="sm">{certification.organization}</Text>
-      </Table.Td>
-      <Table.Td>
-        <AppBadge kind={isActive ? 'active' : 'inactive'}>{isActive ? '有効' : '無効'}</AppBadge>
       </Table.Td>
       <Table.Td onClick={(e) => e.stopPropagation()}>
         <AppButton intent="tertiary" size="xs" onClick={onEdit}>

--- a/src/features/certifications/components/CertificationList.tsx
+++ b/src/features/certifications/components/CertificationList.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState } from 'react';
 
-import { Menu, Stack, Table, Text } from '@mantine/core';
-import { notifications } from '@mantine/notifications';
+import { Group, Paper, Stack, Table, Text } from '@mantine/core';
 import { IconCertificate, IconPlus } from '@tabler/icons-react';
 
 import { ErrorAlert } from '@/components/AppAlert';
@@ -13,12 +12,12 @@ import { InactiveVisibilityToggle } from '@/components/InactiveVisibilityToggle'
 import { ListEmptyState, ListNoResultsState } from '@/components/ListEmptyState';
 import { ListHeader } from '@/components/ListHeader';
 import { ListToolbar } from '@/components/ListToolbar';
-import { RowActionsButton } from '@/components/RowActionsButton';
+import mobileClasses from '@/components/MobileListItem.module.css';
 import { SearchInput } from '@/components/SearchInput';
 import { TableRowsSkeleton } from '@/components/TableRowsSkeleton';
 import { DepartmentTag } from '@/features/departments/DepartmentTag';
 
-import { useCertifications, useDeactivateCertification } from '../queries';
+import { useCertifications } from '../queries';
 import type { Certification } from '../schema';
 import { CertificationDrawer, type CertificationDrawerState } from './CertificationDrawer';
 
@@ -99,26 +98,39 @@ export function CertificationList() {
       )}
 
       {visibleCertifications.length > 0 && (
-        <AppTable minWidth={720}>
-          <Table.Thead>
-            <Table.Tr>
-              <Table.Th>資格名</Table.Th>
-              <Table.Th>部門</Table.Th>
-              <Table.Th>発行団体</Table.Th>
-              <Table.Th w={100}>状態</Table.Th>
-              <Table.Th w={56} />
-            </Table.Tr>
-          </Table.Thead>
-          <Table.Tbody>
+        <>
+          <Stack visibleFrom="sm" gap={0}>
+            <AppTable minWidth={720}>
+              <Table.Thead>
+                <Table.Tr>
+                  <Table.Th>資格名</Table.Th>
+                  <Table.Th>部門</Table.Th>
+                  <Table.Th>発行団体</Table.Th>
+                  <Table.Th w={100}>状態</Table.Th>
+                  <Table.Th w={72} />
+                </Table.Tr>
+              </Table.Thead>
+              <Table.Tbody>
+                {visibleCertifications.map((cert) => (
+                  <CertificationRow
+                    key={cert.id}
+                    certification={cert}
+                    onEdit={() => setDrawerState({ mode: 'edit', certificationId: cert.id })}
+                  />
+                ))}
+              </Table.Tbody>
+            </AppTable>
+          </Stack>
+          <Stack hiddenFrom="sm" gap="sm">
             {visibleCertifications.map((cert) => (
-              <CertificationRow
+              <CertificationMobileRow
                 key={cert.id}
                 certification={cert}
                 onEdit={() => setDrawerState({ mode: 'edit', certificationId: cert.id })}
               />
             ))}
-          </Table.Tbody>
-        </AppTable>
+          </Stack>
+        </>
       )}
 
       <CertificationDrawer state={drawerState} onClose={() => setDrawerState(null)} />
@@ -133,19 +145,7 @@ type CertificationRowProps = {
 
 /** 資格一覧の1行。クリックで編集 Drawer を開く。 */
 function CertificationRow({ certification, onEdit }: CertificationRowProps) {
-  const deactivate = useDeactivateCertification();
   const isActive = certification.isActive;
-
-  const handleDeactivate = () => {
-    deactivate.mutate(certification.id, {
-      onSuccess: () => {
-        notifications.show({
-          color: 'green',
-          message: `${certification.name}を無効化しました`,
-        });
-      },
-    });
-  };
 
   return (
     <ClickableTr onClick={onEdit}>
@@ -167,20 +167,41 @@ function CertificationRow({ certification, onEdit }: CertificationRowProps) {
         <AppBadge kind={isActive ? 'active' : 'inactive'}>{isActive ? '有効' : '無効'}</AppBadge>
       </Table.Td>
       <Table.Td onClick={(e) => e.stopPropagation()}>
-        <Menu position="bottom-end">
-          <Menu.Target>
-            <RowActionsButton />
-          </Menu.Target>
-          <Menu.Dropdown>
-            <Menu.Item onClick={onEdit}>編集</Menu.Item>
-            {isActive && (
-              <Menu.Item onClick={handleDeactivate} disabled={deactivate.isPending}>
-                無効化
-              </Menu.Item>
-            )}
-          </Menu.Dropdown>
-        </Menu>
+        <AppButton intent="tertiary" size="xs" onClick={onEdit}>
+          編集
+        </AppButton>
       </Table.Td>
     </ClickableTr>
+  );
+}
+
+/** モバイル幅で資格を名簿形式に表示する行。 */
+function CertificationMobileRow({ certification, onEdit }: CertificationRowProps) {
+  return (
+    <Paper
+      withBorder
+      p="sm"
+      className={!certification.isActive ? mobileClasses.inactive : undefined}
+    >
+      <Group justify="space-between" align="flex-start" wrap="nowrap">
+        <Stack gap={4}>
+          <Text fw={500} size="sm">
+            {certification.name}
+          </Text>
+          <Group gap="xs">
+            <DepartmentTag code={certification.departmentCode} />
+            <Text c="dimmed" size="xs">
+              {certification.shortName}
+            </Text>
+          </Group>
+          <Text c="dimmed" size="sm">
+            {certification.organization}
+          </Text>
+        </Stack>
+        <AppButton intent="tertiary" size="xs" onClick={onEdit}>
+          編集
+        </AppButton>
+      </Group>
+    </Paper>
   );
 }

--- a/src/features/certifications/components/CertificationList.tsx
+++ b/src/features/certifications/components/CertificationList.tsx
@@ -121,15 +121,17 @@ export function CertificationList() {
               </Table.Tbody>
             </AppTable>
           </Stack>
-          <Stack hiddenFrom="sm" gap="sm">
-            {visibleCertifications.map((cert) => (
-              <CertificationMobileRow
-                key={cert.id}
-                certification={cert}
-                onEdit={() => setDrawerState({ mode: 'edit', certificationId: cert.id })}
-              />
-            ))}
-          </Stack>
+          <Paper hiddenFrom="sm" withBorder p={0}>
+            <Stack gap={0}>
+              {visibleCertifications.map((cert) => (
+                <CertificationMobileRow
+                  key={cert.id}
+                  certification={cert}
+                  onEdit={() => setDrawerState({ mode: 'edit', certificationId: cert.id })}
+                />
+              ))}
+            </Stack>
+          </Paper>
         </>
       )}
 
@@ -178,10 +180,8 @@ function CertificationRow({ certification, onEdit }: CertificationRowProps) {
 /** モバイル幅で資格を名簿形式に表示する行。 */
 function CertificationMobileRow({ certification, onEdit }: CertificationRowProps) {
   return (
-    <Paper
-      withBorder
-      p="sm"
-      className={!certification.isActive ? mobileClasses.inactive : undefined}
+    <div
+      className={`${mobileClasses.row}${!certification.isActive ? ` ${mobileClasses.inactive}` : ''}`}
     >
       <Group justify="space-between" align="flex-start" wrap="nowrap">
         <Stack gap={4}>
@@ -202,6 +202,6 @@ function CertificationMobileRow({ certification, onEdit }: CertificationRowProps
           編集
         </AppButton>
       </Group>
-    </Paper>
+    </div>
   );
 }

--- a/src/features/dashboard/components/DashboardAvailabilityLink.module.css
+++ b/src/features/dashboard/components/DashboardAvailabilityLink.module.css
@@ -1,0 +1,23 @@
+.description {
+  flex: 1;
+}
+
+.button {
+  flex-shrink: 0;
+}
+
+/* 狭い画面では説明と導線を縦に並べ、文言を省略せず操作領域を確保する */
+@media (max-width: 47.999em) {
+  .container {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .guidance {
+    white-space: normal;
+  }
+
+  .button {
+    width: 100%;
+  }
+}

--- a/src/features/dashboard/components/DashboardAvailabilityLink.tsx
+++ b/src/features/dashboard/components/DashboardAvailabilityLink.tsx
@@ -3,22 +3,30 @@ import { IconCalendarEvent } from '@tabler/icons-react';
 
 import { AppButton } from '@/components/AppButton';
 
+import classes from './DashboardAvailabilityLink.module.css';
+
 /** 勤務予定の下に常設するシフト希望への通常導線。 */
 export function DashboardAvailabilityLink() {
   return (
     <Paper withBorder radius="md" p="sm" mt="md">
-      <Group justify="space-between" gap="md" wrap="nowrap">
-        <Group gap="sm" wrap="nowrap" miw={0}>
+      <Group className={classes.container} justify="space-between" gap="md" wrap="nowrap">
+        <Group className={classes.description} gap="sm" wrap="nowrap" miw={0}>
           <IconCalendarEvent size={20} stroke={1.8} />
           <Stack gap={2} miw={0}>
             <Text fw={600}>シフト希望</Text>
-            <Text size="sm" c="dimmed" truncate>
+            <Text className={classes.guidance} size="sm" c="dimmed">
               勤務できない日や調整が必要な日を登録します。
             </Text>
           </Stack>
         </Group>
-        <AppButton intent="secondary" component="a" href="/availabilities" size="sm">
-          確認・変更
+        <AppButton
+          className={classes.button}
+          intent="secondary"
+          component="a"
+          href="/availabilities"
+          size="sm"
+        >
+          シフト希望の確認・変更
         </AppButton>
       </Group>
     </Paper>

--- a/src/features/dashboard/components/UpcomingShifts.module.css
+++ b/src/features/dashboard/components/UpcomingShifts.module.css
@@ -70,6 +70,14 @@
   pointer-events: none;
 }
 
+/* モバイルでは操作ボタンをカレンダーの外へ置き、日付セルとタップ領域を重ねない */
+@media (max-width: 47.999em) {
+  .carouselControls {
+    position: static;
+    margin-top: var(--mantine-spacing-xs);
+  }
+}
+
 /* sm以上は今月・来月が横並びでスワイプ不要になるため、前後矢印を隠す */
 @media (min-width: 48em) {
   .carouselControls {

--- a/src/features/instructors/components/InstructorList.tsx
+++ b/src/features/instructors/components/InstructorList.tsx
@@ -125,7 +125,6 @@ export function InstructorList() {
                 <Table.Tr>
                   <Table.Th>氏名</Table.Th>
                   <Table.Th>資格</Table.Th>
-                  <Table.Th w={120}>状態</Table.Th>
                   <Table.Th>備考</Table.Th>
                   <Table.Th w={72} />
                 </Table.Tr>
@@ -175,7 +174,7 @@ function InstructorRow({ instructor, onEdit }: InstructorRowProps) {
   const hiddenCerts = instructor.certifications.slice(MAX_VISIBLE_CERTS);
 
   return (
-    <ClickableTr onClick={onEdit}>
+    <ClickableTr inactive={!isActive} onClick={onEdit}>
       <Table.Td>
         <Group gap="sm" wrap="nowrap">
           <Avatar color="initials" name={fullName} radius="xl" size="sm" />
@@ -218,9 +217,6 @@ function InstructorRow({ instructor, onEdit }: InstructorRowProps) {
             —
           </Text>
         )}
-      </Table.Td>
-      <Table.Td>
-        <AppBadge kind={isActive ? 'active' : 'inactive'}>{isActive ? '有効' : '無効'}</AppBadge>
       </Table.Td>
       <Table.Td>
         {instructor.notes && (

--- a/src/features/instructors/components/InstructorList.tsx
+++ b/src/features/instructors/components/InstructorList.tsx
@@ -141,15 +141,17 @@ export function InstructorList() {
               </Table.Tbody>
             </AppTable>
           </Stack>
-          <Stack hiddenFrom="sm" gap="sm">
-            {visibleInstructors.map((instructor) => (
-              <InstructorMobileRow
-                key={instructor.id}
-                instructor={instructor}
-                onEdit={() => setDrawerState({ mode: 'edit', instructorId: instructor.id })}
-              />
-            ))}
-          </Stack>
+          <Paper hiddenFrom="sm" withBorder p={0}>
+            <Stack gap={0}>
+              {visibleInstructors.map((instructor) => (
+                <InstructorMobileRow
+                  key={instructor.id}
+                  instructor={instructor}
+                  onEdit={() => setDrawerState({ mode: 'edit', instructorId: instructor.id })}
+                />
+              ))}
+            </Stack>
+          </Paper>
         </>
       )}
 
@@ -244,10 +246,8 @@ function InstructorMobileRow({ instructor, onEdit }: InstructorRowProps) {
   const hiddenCerts = instructor.certifications.slice(MAX_VISIBLE_CERTS);
 
   return (
-    <Paper
-      withBorder
-      p="sm"
-      className={instructor.status === 'INACTIVE' ? mobileClasses.inactive : undefined}
+    <div
+      className={`${mobileClasses.row}${instructor.status === 'INACTIVE' ? ` ${mobileClasses.inactive}` : ''}`}
     >
       <Group justify="space-between" align="flex-start" wrap="nowrap">
         <Group gap="sm" wrap="nowrap">
@@ -291,6 +291,6 @@ function InstructorMobileRow({ instructor, onEdit }: InstructorRowProps) {
           編集
         </AppButton>
       </Group>
-    </Paper>
+    </div>
   );
 }

--- a/src/features/instructors/components/InstructorList.tsx
+++ b/src/features/instructors/components/InstructorList.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState } from 'react';
 
-import { Avatar, Group, Menu, Stack, Table, Text, Tooltip } from '@mantine/core';
-import { notifications } from '@mantine/notifications';
+import { Avatar, Group, Paper, Stack, Table, Text, Tooltip } from '@mantine/core';
 import { IconPlus, IconUsers } from '@tabler/icons-react';
 
 import { ErrorAlert } from '@/components/AppAlert';
@@ -13,11 +12,11 @@ import { InactiveVisibilityToggle } from '@/components/InactiveVisibilityToggle'
 import { ListEmptyState, ListNoResultsState } from '@/components/ListEmptyState';
 import { ListHeader } from '@/components/ListHeader';
 import { ListToolbar } from '@/components/ListToolbar';
-import { RowActionsButton } from '@/components/RowActionsButton';
+import mobileClasses from '@/components/MobileListItem.module.css';
 import { SearchInput } from '@/components/SearchInput';
 import { TableRowsSkeleton } from '@/components/TableRowsSkeleton';
 
-import { useChangeInstructorStatus, useInstructors } from '../queries';
+import { useInstructors } from '../queries';
 import type { InstructorListItem } from '../schema';
 import { InstructorDrawer, type InstructorDrawerState } from './InstructorDrawer';
 
@@ -119,26 +118,39 @@ export function InstructorList() {
       )}
 
       {visibleInstructors.length > 0 && (
-        <AppTable minWidth={640}>
-          <Table.Thead>
-            <Table.Tr>
-              <Table.Th>氏名</Table.Th>
-              <Table.Th>資格</Table.Th>
-              <Table.Th w={120}>状態</Table.Th>
-              <Table.Th>備考</Table.Th>
-              <Table.Th w={56} />
-            </Table.Tr>
-          </Table.Thead>
-          <Table.Tbody>
+        <>
+          <Stack visibleFrom="sm" gap={0}>
+            <AppTable minWidth={640}>
+              <Table.Thead>
+                <Table.Tr>
+                  <Table.Th>氏名</Table.Th>
+                  <Table.Th>資格</Table.Th>
+                  <Table.Th w={120}>状態</Table.Th>
+                  <Table.Th>備考</Table.Th>
+                  <Table.Th w={72} />
+                </Table.Tr>
+              </Table.Thead>
+              <Table.Tbody>
+                {visibleInstructors.map((instructor) => (
+                  <InstructorRow
+                    key={instructor.id}
+                    instructor={instructor}
+                    onEdit={() => setDrawerState({ mode: 'edit', instructorId: instructor.id })}
+                  />
+                ))}
+              </Table.Tbody>
+            </AppTable>
+          </Stack>
+          <Stack hiddenFrom="sm" gap="sm">
             {visibleInstructors.map((instructor) => (
-              <InstructorRow
+              <InstructorMobileRow
                 key={instructor.id}
                 instructor={instructor}
                 onEdit={() => setDrawerState({ mode: 'edit', instructorId: instructor.id })}
               />
             ))}
-          </Table.Tbody>
-        </AppTable>
+          </Stack>
+        </>
       )}
 
       <InstructorDrawer state={drawerState} onClose={() => setDrawerState(null)} />
@@ -153,28 +165,12 @@ type InstructorRowProps = {
 
 /** インストラクター一覧の1行。クリックで編集 Drawer を開く。 */
 function InstructorRow({ instructor, onEdit }: InstructorRowProps) {
-  const changeStatus = useChangeInstructorStatus(instructor.id);
   const isActive = instructor.status === 'ACTIVE';
   const fullName = fullNameOf(instructor);
   const fullNameKana = fullNameKanaOf(instructor);
 
   const visibleCerts = instructor.certifications.slice(0, MAX_VISIBLE_CERTS);
   const hiddenCerts = instructor.certifications.slice(MAX_VISIBLE_CERTS);
-
-  const handleToggleStatus = () => {
-    const nextStatus = isActive ? 'INACTIVE' : 'ACTIVE';
-    changeStatus.mutate(
-      { status: nextStatus },
-      {
-        onSuccess: () => {
-          notifications.show({
-            color: 'green',
-            message: `${fullName}を${nextStatus === 'ACTIVE' ? '有効' : '無効'}にしました`,
-          });
-        },
-      },
-    );
-  };
 
   return (
     <ClickableTr onClick={onEdit}>
@@ -232,18 +228,69 @@ function InstructorRow({ instructor, onEdit }: InstructorRowProps) {
         )}
       </Table.Td>
       <Table.Td onClick={(e) => e.stopPropagation()}>
-        <Menu position="bottom-end">
-          <Menu.Target>
-            <RowActionsButton />
-          </Menu.Target>
-          <Menu.Dropdown>
-            <Menu.Item onClick={onEdit}>編集</Menu.Item>
-            <Menu.Item onClick={handleToggleStatus} disabled={changeStatus.isPending}>
-              {isActive ? '無効にする' : '有効にする'}
-            </Menu.Item>
-          </Menu.Dropdown>
-        </Menu>
+        <AppButton intent="tertiary" size="xs" onClick={onEdit}>
+          編集
+        </AppButton>
       </Table.Td>
     </ClickableTr>
+  );
+}
+
+/** モバイル幅でインストラクターを名簿形式に表示する行。 */
+function InstructorMobileRow({ instructor, onEdit }: InstructorRowProps) {
+  const fullName = fullNameOf(instructor);
+  const fullNameKana = fullNameKanaOf(instructor);
+  const visibleCerts = instructor.certifications.slice(0, MAX_VISIBLE_CERTS);
+  const hiddenCerts = instructor.certifications.slice(MAX_VISIBLE_CERTS);
+
+  return (
+    <Paper
+      withBorder
+      p="sm"
+      className={instructor.status === 'INACTIVE' ? mobileClasses.inactive : undefined}
+    >
+      <Group justify="space-between" align="flex-start" wrap="nowrap">
+        <Group gap="sm" wrap="nowrap">
+          <Avatar color="initials" name={fullName} radius="xl" size="sm" />
+          <Stack gap={4}>
+            <div>
+              <Text fw={500} size="sm">
+                {fullName}
+              </Text>
+              {fullNameKana && (
+                <Text c="dimmed" size="xs">
+                  {fullNameKana}
+                </Text>
+              )}
+            </div>
+            {instructor.certifications.length > 0 && (
+              <Group gap={4} wrap="wrap">
+                {visibleCerts.map((cert) => (
+                  <Tooltip key={cert.id} label={cert.name}>
+                    <AppBadge
+                      kind={cert.isActive ? 'certification' : 'inactive'}
+                      departmentCode={cert.departmentCode}
+                      size="sm"
+                    >
+                      {cert.shortName}
+                    </AppBadge>
+                  </Tooltip>
+                ))}
+                {hiddenCerts.length > 0 && (
+                  <Tooltip label={hiddenCerts.map((cert) => cert.name).join('、')}>
+                    <AppBadge kind="count" size="sm">
+                      +{hiddenCerts.length}
+                    </AppBadge>
+                  </Tooltip>
+                )}
+              </Group>
+            )}
+          </Stack>
+        </Group>
+        <AppButton intent="tertiary" size="xs" onClick={onEdit}>
+          編集
+        </AppButton>
+      </Group>
+    </Paper>
   );
 }

--- a/src/features/invitations/components/ActiveInvitationCard.tsx
+++ b/src/features/invitations/components/ActiveInvitationCard.tsx
@@ -18,6 +18,7 @@ import { AppButton } from '@/components/AppButton';
 import { buildInviteUrl, formatDateTime, remainingLabel } from '../lib';
 import { useDeactivateInvitation } from '../queries';
 import type { Invitation } from '../schema';
+import classes from './active-invitation-card.module.css';
 
 /** 残り時間の強調表示を切り替える閾値（時間） */
 const EXPIRY_WARNING_HOURS = 24;
@@ -48,17 +49,38 @@ export function ActiveInvitationCard({ invitation }: ActiveInvitationCardProps) 
   return (
     <Paper withBorder radius="md" p="lg">
       <Stack gap="md">
-        <Group justify="space-between" align="flex-start" wrap="nowrap">
-          <Group gap="sm" wrap="wrap">
-            <AppBadge kind="active" size="lg">
-              有効
-            </AppBadge>
-            {invitation.description && <Text fw={500}>{invitation.description}</Text>}
-          </Group>
+        <Group gap="sm" wrap="wrap">
+          <AppBadge kind="active" size="lg">
+            有効
+          </AppBadge>
+          {invitation.description && <Text fw={500}>{invitation.description}</Text>}
+        </Group>
 
+        <div className={classes.invitationActions}>
+          <TextInput className={classes.urlInput} readOnly value={url} />
+          <CopyButton value={url} timeout={2000}>
+            {({ copied, copy }) => (
+              <Button
+                className={classes.copyButton}
+                leftSection={
+                  copied ? (
+                    <IconCheck size={16} stroke={1.5} />
+                  ) : (
+                    <IconCopy size={16} stroke={1.5} />
+                  )
+                }
+                {...(copied ? { color: 'teal' } : {})}
+                onClick={copy}
+              >
+                コピー
+              </Button>
+            )}
+          </CopyButton>
           <Popover width={260} position="bottom-end" withArrow>
             <Popover.Target>
               <AppButton
+                className={classes.deactivateButton}
+                compact
                 intent="danger"
                 emphasis="low"
                 leftSection={<IconBan size={16} stroke={1.5} />}
@@ -83,28 +105,7 @@ export function ActiveInvitationCard({ invitation }: ActiveInvitationCardProps) 
               </Stack>
             </Popover.Dropdown>
           </Popover>
-        </Group>
-
-        <Group gap="sm" wrap="nowrap">
-          <TextInput readOnly value={url} flex={1} />
-          <CopyButton value={url} timeout={2000}>
-            {({ copied, copy }) => (
-              <Button
-                leftSection={
-                  copied ? (
-                    <IconCheck size={16} stroke={1.5} />
-                  ) : (
-                    <IconCopy size={16} stroke={1.5} />
-                  )
-                }
-                {...(copied ? { color: 'teal' } : {})}
-                onClick={copy}
-              >
-                {copied ? 'コピーしました' : 'リンクをコピー'}
-              </Button>
-            )}
-          </CopyButton>
-        </Group>
+        </div>
 
         <Group gap="lg">
           <Tooltip label={formatDateTime(invitation.expiresAt)}>

--- a/src/features/invitations/components/InvitationHistoryTable.tsx
+++ b/src/features/invitations/components/InvitationHistoryTable.tsx
@@ -1,6 +1,7 @@
-import { Table, Text } from '@mantine/core';
+import { Group, Paper, Stack, Table, Text } from '@mantine/core';
 
 import { AppBadge, type AppBadgeKind } from '@/components/AppBadge';
+import mobileClasses from '@/components/MobileListItem.module.css';
 
 import { formatDateTime, invitationStatusOf, type InvitationStatus } from '../lib';
 import type { Invitation } from '../schema';
@@ -42,57 +43,88 @@ export function InvitationHistoryTable({ invitations }: InvitationHistoryTablePr
   const now = new Date();
 
   return (
-    <Table.ScrollContainer minWidth={560}>
-      <Table withTableBorder verticalSpacing="sm">
-        <Table.Thead>
-          <Table.Tr>
-            <Table.Th>状態</Table.Th>
-            <Table.Th>メモ</Table.Th>
-            <Table.Th>有効期限</Table.Th>
-            <Table.Th>使用回数</Table.Th>
-            <Table.Th>作成日時</Table.Th>
-          </Table.Tr>
-        </Table.Thead>
-        <Table.Tbody>
-          {invitations.map((invitation) => {
-            const status = invitationStatusOf(invitation, now);
-            return (
-              <Table.Tr key={invitation.token}>
-                <Table.Td>
-                  <AppBadge kind={STATUS_BADGE_KINDS[status]} size="sm">
-                    {STATUS_LABELS[status]}
-                  </AppBadge>
-                </Table.Td>
-                <Table.Td>
-                  {invitation.description ? (
-                    <Text size="sm" lineClamp={1}>
-                      {invitation.description}
-                    </Text>
-                  ) : (
-                    <Text c="dimmed" size="sm">
-                      —
-                    </Text>
-                  )}
-                </Table.Td>
-                <Table.Td>
-                  <Text size="sm">{formatDateTime(invitation.expiresAt)}</Text>
-                </Table.Td>
-                <Table.Td>
-                  <Text size="sm">
-                    {invitation.usedCount}
-                    {invitation.maxUses !== null ? ` / ${invitation.maxUses}` : ''}
-                  </Text>
-                </Table.Td>
-                <Table.Td>
-                  <Text c="dimmed" size="sm">
-                    {formatDateTime(invitation.createdAt)}
-                  </Text>
-                </Table.Td>
-              </Table.Tr>
-            );
-          })}
-        </Table.Tbody>
-      </Table>
-    </Table.ScrollContainer>
+    <>
+      <Table.ScrollContainer minWidth={560} visibleFrom="sm">
+        <Table withTableBorder verticalSpacing="sm">
+          <Table.Thead>
+            <Table.Tr>
+              <Table.Th>状態</Table.Th>
+              <Table.Th>メモ</Table.Th>
+              <Table.Th>有効期限</Table.Th>
+              <Table.Th>使用回数</Table.Th>
+              <Table.Th>作成日時</Table.Th>
+            </Table.Tr>
+          </Table.Thead>
+          <Table.Tbody>
+            {invitations.map((invitation) => (
+              <InvitationTableRow key={invitation.token} invitation={invitation} now={now} />
+            ))}
+          </Table.Tbody>
+        </Table>
+      </Table.ScrollContainer>
+      <Stack hiddenFrom="sm" gap="sm">
+        {invitations.map((invitation) => (
+          <InvitationMobileRow key={invitation.token} invitation={invitation} now={now} />
+        ))}
+      </Stack>
+    </>
+  );
+}
+
+type InvitationRowProps = { invitation: Invitation; now: Date };
+
+/** デスクトップの招待履歴テーブル行。 */
+function InvitationTableRow({ invitation, now }: InvitationRowProps) {
+  const status = invitationStatusOf(invitation, now);
+  return (
+    <Table.Tr>
+      <Table.Td>
+        <AppBadge kind={STATUS_BADGE_KINDS[status]} size="sm">
+          {STATUS_LABELS[status]}
+        </AppBadge>
+      </Table.Td>
+      <Table.Td>
+        <Text size="sm" lineClamp={1}>
+          {invitation.description || '—'}
+        </Text>
+      </Table.Td>
+      <Table.Td>
+        <Text size="sm">{formatDateTime(invitation.expiresAt)}</Text>
+      </Table.Td>
+      <Table.Td>
+        <Text size="sm">
+          {invitation.usedCount}
+          {invitation.maxUses !== null ? ` / ${invitation.maxUses}` : ''}
+        </Text>
+      </Table.Td>
+      <Table.Td>
+        <Text c="dimmed" size="sm">
+          {formatDateTime(invitation.createdAt)}
+        </Text>
+      </Table.Td>
+    </Table.Tr>
+  );
+}
+
+/** モバイル幅で招待履歴を名簿形式に表示する行。 */
+function InvitationMobileRow({ invitation, now }: InvitationRowProps) {
+  const status = invitationStatusOf(invitation, now);
+  return (
+    <Paper withBorder p="sm" className={status === 'active' ? undefined : mobileClasses.inactive}>
+      <Group justify="space-between" align="flex-start" wrap="nowrap">
+        <Stack gap={4}>
+          <Text fw={500} size="sm">
+            {invitation.description || 'メモなし'}
+          </Text>
+          <Text c="dimmed" size="xs">
+            有効期限: {formatDateTime(invitation.expiresAt)}
+          </Text>
+          <Text c="dimmed" size="xs">
+            使用回数: {invitation.usedCount}
+            {invitation.maxUses !== null ? ` / ${invitation.maxUses}` : ''}
+          </Text>
+        </Stack>
+      </Group>
+    </Paper>
   );
 }

--- a/src/features/invitations/components/InvitationHistoryTable.tsx
+++ b/src/features/invitations/components/InvitationHistoryTable.tsx
@@ -62,11 +62,13 @@ export function InvitationHistoryTable({ invitations }: InvitationHistoryTablePr
           </Table.Tbody>
         </Table>
       </Table.ScrollContainer>
-      <Stack hiddenFrom="sm" gap="sm">
-        {invitations.map((invitation) => (
-          <InvitationMobileRow key={invitation.token} invitation={invitation} now={now} />
-        ))}
-      </Stack>
+      <Paper hiddenFrom="sm" withBorder p={0}>
+        <Stack gap={0}>
+          {invitations.map((invitation) => (
+            <InvitationMobileRow key={invitation.token} invitation={invitation} now={now} />
+          ))}
+        </Stack>
+      </Paper>
     </>
   );
 }
@@ -109,8 +111,10 @@ function InvitationTableRow({ invitation, now }: InvitationRowProps) {
 /** モバイル幅で招待履歴を名簿形式に表示する行。 */
 function InvitationMobileRow({ invitation, now }: InvitationRowProps) {
   const status = invitationStatusOf(invitation, now);
+  const className =
+    status === 'active' ? mobileClasses.row : `${mobileClasses.row} ${mobileClasses.inactive}`;
   return (
-    <Paper withBorder p="sm" className={status === 'active' ? undefined : mobileClasses.inactive}>
+    <div className={className}>
       <Group justify="space-between" align="flex-start" wrap="nowrap">
         <Stack gap={4}>
           <Text fw={500} size="sm">
@@ -125,6 +129,6 @@ function InvitationMobileRow({ invitation, now }: InvitationRowProps) {
           </Text>
         </Stack>
       </Group>
-    </Paper>
+    </div>
   );
 }

--- a/src/features/invitations/components/active-invitation-card.module.css
+++ b/src/features/invitations/components/active-invitation-card.module.css
@@ -1,0 +1,26 @@
+.invitationActions {
+  display: flex;
+  gap: var(--mantine-spacing-sm);
+  min-width: 0;
+}
+
+.urlInput {
+  flex: 1;
+  min-width: 0;
+}
+
+/* モバイルではリンクを独立した行にし、操作ボタンのタップ領域を確保する。 */
+@media (max-width: 48em) {
+  .invitationActions {
+    flex-wrap: wrap;
+  }
+
+  .urlInput {
+    flex-basis: 100%;
+  }
+
+  .copyButton,
+  .deactivateButton {
+    flex: 1;
+  }
+}

--- a/src/features/shift-types/components/ShiftTypeList.tsx
+++ b/src/features/shift-types/components/ShiftTypeList.tsx
@@ -138,20 +138,22 @@ export function ShiftTypeList({
               </Table.Tbody>
             </AppTable>
           </Stack>
-          <Stack hiddenFrom="sm" gap="sm">
-            {visibleShiftTypes.map((shiftType) => (
-              <ShiftTypeMobileRow
-                key={shiftType.id}
-                shiftType={shiftType}
-                rowAction={renderRowAction?.(shiftType)}
-                onEdit={() =>
-                  onOpenForm
-                    ? onOpenForm({ mode: 'edit', shiftTypeId: shiftType.id })
-                    : setDrawerState({ mode: 'edit', shiftTypeId: shiftType.id })
-                }
-              />
-            ))}
-          </Stack>
+          <Paper hiddenFrom="sm" withBorder p={0}>
+            <Stack gap={0}>
+              {visibleShiftTypes.map((shiftType) => (
+                <ShiftTypeMobileRow
+                  key={shiftType.id}
+                  shiftType={shiftType}
+                  rowAction={renderRowAction?.(shiftType)}
+                  onEdit={() =>
+                    onOpenForm
+                      ? onOpenForm({ mode: 'edit', shiftTypeId: shiftType.id })
+                      : setDrawerState({ mode: 'edit', shiftTypeId: shiftType.id })
+                  }
+                />
+              ))}
+            </Stack>
+          </Paper>
         </>
       )}
 
@@ -163,7 +165,9 @@ export function ShiftTypeList({
 /** モバイル幅でシフト種別を名簿形式に表示する行。 */
 function ShiftTypeMobileRow({ shiftType, rowAction, onEdit }: ShiftTypeRowProps) {
   return (
-    <Paper withBorder p="sm" className={!shiftType.isActive ? mobileClasses.inactive : undefined}>
+    <div
+      className={`${mobileClasses.row}${!shiftType.isActive ? ` ${mobileClasses.inactive}` : ''}`}
+    >
       <Group justify="space-between" align="center" wrap="nowrap">
         <Text fw={500} size="sm">
           {shiftType.name}
@@ -175,7 +179,7 @@ function ShiftTypeMobileRow({ shiftType, rowAction, onEdit }: ShiftTypeRowProps)
           </AppButton>
         </Group>
       </Group>
-    </Paper>
+    </div>
   );
 }
 

--- a/src/features/shift-types/components/ShiftTypeList.tsx
+++ b/src/features/shift-types/components/ShiftTypeList.tsx
@@ -4,7 +4,6 @@ import { Group, Paper, Stack, Table, Text } from '@mantine/core';
 import { IconClock, IconPlus } from '@tabler/icons-react';
 
 import { ErrorAlert } from '@/components/AppAlert';
-import { AppBadge } from '@/components/AppBadge';
 import { AppButton } from '@/components/AppButton';
 import { AppTable } from '@/components/AppTable';
 import { ClickableTr } from '@/components/ClickableTr';
@@ -118,7 +117,6 @@ export function ShiftTypeList({
               <Table.Thead>
                 <Table.Tr>
                   <Table.Th>種別名</Table.Th>
-                  <Table.Th w={120}>状態</Table.Th>
                   {renderRowAction && <Table.Th w={48}>{rowActionHeader}</Table.Th>}
                 </Table.Tr>
               </Table.Thead>
@@ -191,16 +189,12 @@ type ShiftTypeRowProps = {
 
 /** シフト種別一覧の1行。クリックで編集 Drawer を開く。 */
 function ShiftTypeRow({ shiftType, rowAction, onEdit }: ShiftTypeRowProps) {
-  const isActive = shiftType.isActive;
   return (
-    <ClickableTr onClick={onEdit}>
+    <ClickableTr inactive={!shiftType.isActive} onClick={onEdit}>
       <Table.Td>
         <Text fw={500} size="sm">
           {shiftType.name}
         </Text>
-      </Table.Td>
-      <Table.Td>
-        <AppBadge kind={isActive ? 'active' : 'inactive'}>{isActive ? '有効' : '無効'}</AppBadge>
       </Table.Td>
       {rowAction && <Table.Td onClick={(event) => event.stopPropagation()}>{rowAction}</Table.Td>}
     </ClickableTr>

--- a/src/features/shift-types/components/ShiftTypeList.tsx
+++ b/src/features/shift-types/components/ShiftTypeList.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState, type ReactNode } from 'react';
 
-import { Stack, Table, Text } from '@mantine/core';
+import { Group, Paper, Stack, Table, Text } from '@mantine/core';
 import { IconClock, IconPlus } from '@tabler/icons-react';
 
 import { ErrorAlert } from '@/components/AppAlert';
@@ -12,6 +12,7 @@ import { InactiveVisibilityToggle } from '@/components/InactiveVisibilityToggle'
 import { ListEmptyState, ListNoResultsState } from '@/components/ListEmptyState';
 import { ListHeader } from '@/components/ListHeader';
 import { ListToolbar } from '@/components/ListToolbar';
+import mobileClasses from '@/components/MobileListItem.module.css';
 import { SearchInput } from '@/components/SearchInput';
 import { TableRowsSkeleton } from '@/components/TableRowsSkeleton';
 
@@ -111,17 +112,35 @@ export function ShiftTypeList({
       )}
 
       {visibleShiftTypes.length > 0 && (
-        <AppTable minWidth={400}>
-          <Table.Thead>
-            <Table.Tr>
-              <Table.Th>種別名</Table.Th>
-              <Table.Th w={120}>状態</Table.Th>
-              {renderRowAction && <Table.Th w={48}>{rowActionHeader}</Table.Th>}
-            </Table.Tr>
-          </Table.Thead>
-          <Table.Tbody>
+        <>
+          <Stack visibleFrom="sm" gap={0}>
+            <AppTable minWidth={400}>
+              <Table.Thead>
+                <Table.Tr>
+                  <Table.Th>種別名</Table.Th>
+                  <Table.Th w={120}>状態</Table.Th>
+                  {renderRowAction && <Table.Th w={48}>{rowActionHeader}</Table.Th>}
+                </Table.Tr>
+              </Table.Thead>
+              <Table.Tbody>
+                {visibleShiftTypes.map((shiftType) => (
+                  <ShiftTypeRow
+                    key={shiftType.id}
+                    shiftType={shiftType}
+                    rowAction={renderRowAction?.(shiftType)}
+                    onEdit={() =>
+                      onOpenForm
+                        ? onOpenForm({ mode: 'edit', shiftTypeId: shiftType.id })
+                        : setDrawerState({ mode: 'edit', shiftTypeId: shiftType.id })
+                    }
+                  />
+                ))}
+              </Table.Tbody>
+            </AppTable>
+          </Stack>
+          <Stack hiddenFrom="sm" gap="sm">
             {visibleShiftTypes.map((shiftType) => (
-              <ShiftTypeRow
+              <ShiftTypeMobileRow
                 key={shiftType.id}
                 shiftType={shiftType}
                 rowAction={renderRowAction?.(shiftType)}
@@ -132,12 +151,31 @@ export function ShiftTypeList({
                 }
               />
             ))}
-          </Table.Tbody>
-        </AppTable>
+          </Stack>
+        </>
       )}
 
       {!onOpenForm && <ShiftTypeDrawer state={drawerState} onClose={() => setDrawerState(null)} />}
     </Stack>
+  );
+}
+
+/** モバイル幅でシフト種別を名簿形式に表示する行。 */
+function ShiftTypeMobileRow({ shiftType, rowAction, onEdit }: ShiftTypeRowProps) {
+  return (
+    <Paper withBorder p="sm" className={!shiftType.isActive ? mobileClasses.inactive : undefined}>
+      <Group justify="space-between" align="center" wrap="nowrap">
+        <Text fw={500} size="sm">
+          {shiftType.name}
+        </Text>
+        <Group gap="xs" wrap="nowrap">
+          {rowAction}
+          <AppButton intent="tertiary" size="xs" onClick={onEdit}>
+            編集
+          </AppButton>
+        </Group>
+      </Group>
+    </Paper>
   );
 }
 

--- a/src/features/users/components/UserList.tsx
+++ b/src/features/users/components/UserList.tsx
@@ -96,15 +96,17 @@ export function UserList() {
               </Table.Tbody>
             </AppTable>
           </Stack>
-          <Stack hiddenFrom="sm" gap="sm">
-            {visibleUsers.map((user) => (
-              <UserMobileRow
-                key={user.id}
-                user={user}
-                onEdit={() => setDrawerState({ userId: user.id })}
-              />
-            ))}
-          </Stack>
+          <Paper hiddenFrom="sm" withBorder p={0}>
+            <Stack gap={0}>
+              {visibleUsers.map((user) => (
+                <UserMobileRow
+                  key={user.id}
+                  user={user}
+                  onEdit={() => setDrawerState({ userId: user.id })}
+                />
+              ))}
+            </Stack>
+          </Paper>
         </>
       )}
 
@@ -166,7 +168,7 @@ function UserMobileRow({ user, onEdit }: UserRowProps) {
   const roleMeta = USER_ROLE_META[user.role];
 
   return (
-    <Paper withBorder p="sm" className={!user.isActive ? mobileClasses.inactive : undefined}>
+    <div className={`${mobileClasses.row}${!user.isActive ? ` ${mobileClasses.inactive}` : ''}`}>
       <Group justify="space-between" align="flex-start" wrap="nowrap">
         <Group gap="sm" wrap="nowrap">
           {user.pictureUrl ? (
@@ -190,6 +192,6 @@ function UserMobileRow({ user, onEdit }: UserRowProps) {
           編集
         </AppButton>
       </Group>
-    </Paper>
+    </div>
   );
 }

--- a/src/features/users/components/UserList.tsx
+++ b/src/features/users/components/UserList.tsx
@@ -1,22 +1,22 @@
 import { useMemo, useState } from 'react';
 
-import { Avatar, Group, Menu, Stack, Table, Text } from '@mantine/core';
-import { notifications } from '@mantine/notifications';
+import { Avatar, Group, Paper, Stack, Table, Text } from '@mantine/core';
 import { IconUsers } from '@tabler/icons-react';
 
 import { ErrorAlert } from '@/components/AppAlert';
 import { AppBadge } from '@/components/AppBadge';
+import { AppButton } from '@/components/AppButton';
 import { AppTable } from '@/components/AppTable';
 import { ClickableTr } from '@/components/ClickableTr';
 import { InactiveVisibilityToggle } from '@/components/InactiveVisibilityToggle';
 import { ListEmptyState, ListNoResultsState } from '@/components/ListEmptyState';
 import { ListHeader } from '@/components/ListHeader';
 import { ListToolbar } from '@/components/ListToolbar';
-import { RowActionsButton } from '@/components/RowActionsButton';
+import mobileClasses from '@/components/MobileListItem.module.css';
 import { SearchInput } from '@/components/SearchInput';
 import { TableRowsSkeleton } from '@/components/TableRowsSkeleton';
 
-import { useActivateUser, useDeactivateUser, useUsers } from '../queries';
+import { useUsers } from '../queries';
 import { USER_ROLE_META } from '../role-meta';
 import type { User } from '../schema';
 import { UserDrawer, type UserDrawerState } from './UserDrawer';
@@ -73,26 +73,39 @@ export function UserList() {
       )}
 
       {visibleUsers.length > 0 && (
-        <AppTable minWidth={640}>
-          <Table.Thead>
-            <Table.Tr>
-              <Table.Th>ユーザー名</Table.Th>
-              <Table.Th w={140}>ロール</Table.Th>
-              <Table.Th>Instructor リンク</Table.Th>
-              <Table.Th w={120}>状態</Table.Th>
-              <Table.Th w={56} />
-            </Table.Tr>
-          </Table.Thead>
-          <Table.Tbody>
+        <>
+          <Stack visibleFrom="sm" gap={0}>
+            <AppTable minWidth={640}>
+              <Table.Thead>
+                <Table.Tr>
+                  <Table.Th>ユーザー名</Table.Th>
+                  <Table.Th w={140}>ロール</Table.Th>
+                  <Table.Th>Instructor リンク</Table.Th>
+                  <Table.Th w={120}>状態</Table.Th>
+                  <Table.Th w={72} />
+                </Table.Tr>
+              </Table.Thead>
+              <Table.Tbody>
+                {visibleUsers.map((user) => (
+                  <UserRow
+                    key={user.id}
+                    user={user}
+                    onEdit={() => setDrawerState({ userId: user.id })}
+                  />
+                ))}
+              </Table.Tbody>
+            </AppTable>
+          </Stack>
+          <Stack hiddenFrom="sm" gap="sm">
             {visibleUsers.map((user) => (
-              <UserRow
+              <UserMobileRow
                 key={user.id}
                 user={user}
                 onEdit={() => setDrawerState({ userId: user.id })}
               />
             ))}
-          </Table.Tbody>
-        </AppTable>
+          </Stack>
+        </>
       )}
 
       <UserDrawer state={drawerState} onClose={() => setDrawerState(null)} />
@@ -107,23 +120,8 @@ type UserRowProps = {
 
 /** ユーザー一覧の1行。クリックで編集 Drawer を開く。 */
 function UserRow({ user, onEdit }: UserRowProps) {
-  const deactivate = useDeactivateUser(user.id);
-  const activate = useActivateUser(user.id);
   const isActive = user.isActive;
   const roleMeta = USER_ROLE_META[user.role];
-
-  /** 行メニューからのステータス切り替え（無効⇔有効）を実行する */
-  const handleToggleStatus = () => {
-    const mutation = isActive ? deactivate : activate;
-    mutation.mutate(undefined, {
-      onSuccess: () => {
-        notifications.show({
-          color: 'green',
-          message: `${user.displayName}を${isActive ? '無効' : '有効'}にしました`,
-        });
-      },
-    });
-  };
 
   return (
     <ClickableTr onClick={onEdit}>
@@ -155,21 +153,43 @@ function UserRow({ user, onEdit }: UserRowProps) {
         <AppBadge kind={isActive ? 'active' : 'inactive'}>{isActive ? '有効' : '無効'}</AppBadge>
       </Table.Td>
       <Table.Td onClick={(e) => e.stopPropagation()}>
-        <Menu position="bottom-end">
-          <Menu.Target>
-            <RowActionsButton />
-          </Menu.Target>
-          <Menu.Dropdown>
-            <Menu.Item onClick={onEdit}>編集</Menu.Item>
-            <Menu.Item
-              onClick={handleToggleStatus}
-              disabled={deactivate.isPending || activate.isPending}
-            >
-              {isActive ? '無効にする' : '有効にする'}
-            </Menu.Item>
-          </Menu.Dropdown>
-        </Menu>
+        <AppButton intent="tertiary" size="xs" onClick={onEdit}>
+          編集
+        </AppButton>
       </Table.Td>
     </ClickableTr>
+  );
+}
+
+/** モバイル幅でユーザーを名簿形式に表示する行。 */
+function UserMobileRow({ user, onEdit }: UserRowProps) {
+  const roleMeta = USER_ROLE_META[user.role];
+
+  return (
+    <Paper withBorder p="sm" className={!user.isActive ? mobileClasses.inactive : undefined}>
+      <Group justify="space-between" align="flex-start" wrap="nowrap">
+        <Group gap="sm" wrap="nowrap">
+          {user.pictureUrl ? (
+            <Avatar src={user.pictureUrl} radius="xl" size="sm" />
+          ) : (
+            <Avatar color="initials" name={user.displayName} radius="xl" size="sm" />
+          )}
+          <Stack gap={4}>
+            <Text fw={500} size="sm">
+              {user.displayName}
+            </Text>
+            <Group gap="xs">
+              <AppBadge kind={roleMeta.badgeKind} size="sm">
+                {roleMeta.label}
+              </AppBadge>
+              {user.instructorId && <AppBadge kind="link">リンク済み</AppBadge>}
+            </Group>
+          </Stack>
+        </Group>
+        <AppButton intent="tertiary" size="xs" onClick={onEdit}>
+          編集
+        </AppButton>
+      </Group>
+    </Paper>
   );
 }

--- a/src/features/users/components/UserList.tsx
+++ b/src/features/users/components/UserList.tsx
@@ -81,7 +81,6 @@ export function UserList() {
                   <Table.Th>ユーザー名</Table.Th>
                   <Table.Th w={140}>ロール</Table.Th>
                   <Table.Th>Instructor リンク</Table.Th>
-                  <Table.Th w={120}>状態</Table.Th>
                   <Table.Th w={72} />
                 </Table.Tr>
               </Table.Thead>
@@ -122,11 +121,10 @@ type UserRowProps = {
 
 /** ユーザー一覧の1行。クリックで編集 Drawer を開く。 */
 function UserRow({ user, onEdit }: UserRowProps) {
-  const isActive = user.isActive;
   const roleMeta = USER_ROLE_META[user.role];
 
   return (
-    <ClickableTr onClick={onEdit}>
+    <ClickableTr inactive={!user.isActive} onClick={onEdit}>
       <Table.Td>
         <Group gap="sm" wrap="nowrap">
           {user.pictureUrl ? (
@@ -150,9 +148,6 @@ function UserRow({ user, onEdit }: UserRowProps) {
             —
           </Text>
         )}
-      </Table.Td>
-      <Table.Td>
-        <AppBadge kind={isActive ? 'active' : 'inactive'}>{isActive ? '有効' : '無効'}</AppBadge>
       </Table.Td>
       <Table.Td onClick={(e) => e.stopPropagation()}>
         <AppButton intent="tertiary" size="xs" onClick={onEdit}>


### PR DESCRIPTION
## 概要

モバイル幅での各種一覧・ダッシュボード・招待画面の操作性を改善する。
一覧は行ごとのカードから名簿形式に統一し、状態表示は背景色に一本化する。

## やったこと

- モバイルでは招待 URL と操作ボタンを別行にし、コピー表記を統一
- ダッシュボードのシフト希望導線を全文表示にし、カレンダー操作ボタンをカレンダー外へ移動
- 固定表示の未保存変更バーがコンテンツ末尾を隠さないよう、表示中のスクロール余白を追加
- モバイル幅で一覧を名簿形式に切り替え、無効項目を背景色で識別するよう変更
- モバイル一覧を行カードから区切り線付きの単一名簿コンテナへ変更
- 有効・無効の状態列を廃止し、無効行は背景色のみで識別（状態変更は既存 Drawer に集約）

## レビューポイント

- 状態列廃止・名簿形式化は CertificationList / InstructorList / ShiftTypeList / UserList / InvitationHistoryTable の5つの一覧に横断適用されている。表示崩れや無効行の視認性を各一覧で確認したい
- `UnsavedChangesBar` の `padding-bottom` 追加は `:has()` セレクタで AppShell 全体に影響するため、他画面での余白の出方も確認したい

## 備考

- UI/UX 変更のためスクリーンショット・動画は別途添付をお願いします